### PR TITLE
Implement vendor signup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,11 +23,11 @@ def get_db():
 # Rota de registro de utilizador
 @app.post("/users/", response_model=schemas.UserOut)
 def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
-    db_user = db.query(models.User).filter(models.User.username == user.username).first()
+    db_user = db.query(models.User).filter(models.User.email == user.email).first()
     if db_user:
-        raise HTTPException(status_code=400, detail="Username already registered")
+        raise HTTPException(status_code=400, detail="Email already registered")
     hashed_password = pwd_context.hash(user.password)
-    new_user = models.User(username=user.username, hashed_password=hashed_password, role=user.role)
+    new_user = models.User(email=user.email, hashed_password=hashed_password, role=user.role, date_of_birth=user.date_of_birth)
     db.add(new_user)
     db.commit()
     db.refresh(new_user)
@@ -36,6 +36,28 @@ def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
         db.add(vendor)
         db.commit()
     return new_user
+
+# Rota de registro de vendedor
+@app.post("/vendors/", response_model=schemas.VendorOut)
+def create_vendor(vendor: schemas.VendorCreate, db: Session = Depends(get_db)):
+    db_user = db.query(models.User).filter(models.User.email == vendor.email).first()
+    if db_user:
+        raise HTTPException(status_code=400, detail="Email already registered")
+    hashed_password = pwd_context.hash(vendor.password)
+    new_user = models.User(
+        email=vendor.email,
+        hashed_password=hashed_password,
+        role="vendor",
+        date_of_birth=vendor.date_of_birth,
+    )
+    db.add(new_user)
+    db.commit()
+    db.refresh(new_user)
+    new_vendor = models.Vendor(user_id=new_user.id, product=vendor.product)
+    db.add(new_vendor)
+    db.commit()
+    db.refresh(new_vendor)
+    return new_vendor
 
 # Rota para atualizar localização do vendedor
 @app.put("/vendors/{vendor_id}", response_model=schemas.VendorOut)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,5 @@
 # models.py - define as tabelas no PostgreSQL
-from sqlalchemy import Column, Integer, String, Float, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, String, Float, DateTime, ForeignKey, Date
 from sqlalchemy.orm import relationship
 from .database import Base
 from datetime import datetime
@@ -8,9 +8,10 @@ class User(Base):
     __tablename__ = "users"  # tabela de utilizadores
 
     id = Column(Integer, primary_key=True, index=True)
-    username = Column(String, unique=True, index=True)
+    email = Column(String, unique=True, index=True)
     hashed_password = Column(String)
     role = Column(String)  # 'vendor' ou 'customer'
+    date_of_birth = Column(Date)
 
     vendor = relationship("Vendor", back_populates="user", uselist=False)
 
@@ -19,6 +20,7 @@ class Vendor(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"))
+    product = Column(String)
     current_lat = Column(Float)
     current_lng = Column(Float)
     last_update = Column(DateTime, default=datetime.utcnow)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,17 +1,19 @@
 # schemas.py - define os formatos de dados para entrada e saída
 from pydantic import BaseModel
-from typing import Optional
-from datetime import datetime
+from typing import Optional, Literal
+from datetime import datetime, date
 
 class UserCreate(BaseModel):
-    username: str
+    email: str
     password: str
     role: str  # 'vendor' ou 'customer'
+    date_of_birth: date
 
 class UserOut(BaseModel):
     id: int
-    username: str
+    email: str
     role: str
+    date_of_birth: date
 
     class Config:
         orm_mode = True
@@ -20,8 +22,15 @@ class VendorUpdate(BaseModel):
     current_lat: float
     current_lng: float
 
+class VendorCreate(BaseModel):
+    email: str
+    password: str
+    date_of_birth: date
+    product: Literal["Bolas de Berlim", "Gelados", "Acess\u00f3rios"]
+
 class VendorOut(BaseModel):
     id: int
+    product: str
     current_lat: float
     current_lng: float
     last_update: datetime


### PR DESCRIPTION
## Summary
- support new vendor fields in DB schema
- add POST `/vendors/` for vendor signup
- update models and schemas with email, birthdate and product

## Testing
- `python -m py_compile backend/app/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840aeed4768832e8a87f568e1700efe