### PR TITLE
Implement vendor login and profile update

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -18,6 +18,16 @@ class UserOut(BaseModel):
     class Config:
         orm_mode = True
 
+class UserLogin(BaseModel):
+    email: str
+    password: str
+
+class VendorProfileUpdate(BaseModel):
+    email: Optional[str] = None
+    password: Optional[str] = None
+    date_of_birth: Optional[date] = None
+    product: Optional[Literal["Bolas de Berlim", "Gelados", "Acess\u00f3rios"]] = None
+
 class VendorUpdate(BaseModel):
     current_lat: float
     current_lng: float


### PR DESCRIPTION
## Summary
- add login route for vendors/users
- add vendor profile update endpoint
- extend schemas with login and vendor profile updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b1b275b0832eb0e3b9be1efff1bf