### PR TITLE
Simplify vendor features

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,13 +12,16 @@ app = FastAPI()
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-# Rota de login
-@app.post("/login", response_model=schemas.UserOut)
+# Rota de login do vendedor
+@app.post("/login", response_model=schemas.VendorOut)
 def login(credentials: schemas.UserLogin, db: Session = Depends(get_db)):
     user = db.query(models.User).filter(models.User.email == credentials.email).first()
     if not user or not pwd_context.verify(credentials.password, user.hashed_password):
         raise HTTPException(status_code=400, detail="Incorrect email or password")
-    return user
+    vendor = user.vendor
+    if vendor is None:
+        raise HTTPException(status_code=400, detail="Vendor not found")
+    return vendor
 
 # Dependência para obter a sessão
 def get_db():
@@ -28,22 +31,6 @@ def get_db():
     finally:
         db.close()
 
-# Rota de registro de utilizador
-@app.post("/users/", response_model=schemas.UserOut)
-def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
-    db_user = db.query(models.User).filter(models.User.email == user.email).first()
-    if db_user:
-        raise HTTPException(status_code=400, detail="Email already registered")
-    hashed_password = pwd_context.hash(user.password)
-    new_user = models.User(email=user.email, hashed_password=hashed_password, role=user.role, date_of_birth=user.date_of_birth)
-    db.add(new_user)
-    db.commit()
-    db.refresh(new_user)
-    if user.role == 'vendor':
-        vendor = models.Vendor(user_id=new_user.id)
-        db.add(vendor)
-        db.commit()
-    return new_user
 
 # Rota de registro de vendedor
 @app.post("/vendors/", response_model=schemas.VendorOut)
@@ -56,33 +43,20 @@ def create_vendor(vendor: schemas.VendorCreate, db: Session = Depends(get_db)):
         email=vendor.email,
         hashed_password=hashed_password,
         role="vendor",
-        date_of_birth=vendor.date_of_birth,
     )
     db.add(new_user)
     db.commit()
     db.refresh(new_user)
-    new_vendor = models.Vendor(user_id=new_user.id, product=vendor.product)
+    new_vendor = models.Vendor(
+        user_id=new_user.id,
+        product=vendor.product,
+        profile_photo=vendor.profile_photo,
+    )
     db.add(new_vendor)
     db.commit()
     db.refresh(new_vendor)
     return new_vendor
 
-# Rota para atualizar localização do vendedor
-@app.put("/vendors/{vendor_id}", response_model=schemas.VendorOut)
-def update_vendor(vendor_id: int, update: schemas.VendorUpdate, db: Session = Depends(get_db)):
-    vendor = db.query(models.Vendor).filter(models.Vendor.id == vendor_id).first()
-    if not vendor:
-        raise HTTPException(status_code=404, detail="Vendor not found")
-    vendor.current_lat = update.current_lat
-    vendor.current_lng = update.current_lng
-    db.commit()
-    db.refresh(vendor)
-    return vendor
-
-# Rota para obter vendedores ativos
-@app.get("/vendors/", response_model=list[schemas.VendorOut])
-def list_vendors(db: Session = Depends(get_db)):
-    return db.query(models.Vendor).all()
 
 # Rota para atualizar informações do perfil do vendedor
 @app.put("/vendors/{vendor_id}/profile", response_model=schemas.VendorOut)
@@ -99,10 +73,10 @@ def update_vendor_profile(
         user.email = update.email
     if update.password is not None:
         user.hashed_password = pwd_context.hash(update.password)
-    if update.date_of_birth is not None:
-        user.date_of_birth = update.date_of_birth
     if update.product is not None:
         vendor.product = update.product
+    if update.profile_photo is not None:
+        vendor.profile_photo = update.profile_photo
     db.commit()
     db.refresh(vendor)
     return vendor

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,8 +1,7 @@
 # models.py - define as tabelas no PostgreSQL
-from sqlalchemy import Column, Integer, String, Float, DateTime, ForeignKey, Date
+from sqlalchemy import Column, Integer, String, ForeignKey
 from sqlalchemy.orm import relationship
 from .database import Base
-from datetime import datetime
 
 class User(Base):
     __tablename__ = "users"  # tabela de utilizadores
@@ -10,8 +9,7 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String, unique=True, index=True)
     hashed_password = Column(String)
-    role = Column(String)  # 'vendor' ou 'customer'
-    date_of_birth = Column(Date)
+    role = Column(String, default="vendor")
 
     vendor = relationship("Vendor", back_populates="user", uselist=False)
 
@@ -21,8 +19,6 @@ class Vendor(Base):
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"))
     product = Column(String)
-    current_lat = Column(Float)
-    current_lng = Column(Float)
-    last_update = Column(DateTime, default=datetime.utcnow)
+    profile_photo = Column(String)
 
     user = relationship("User", back_populates="vendor")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,19 +1,10 @@
 # schemas.py - define os formatos de dados para entrada e saída
 from pydantic import BaseModel
 from typing import Optional, Literal
-from datetime import datetime, date
-
-class UserCreate(BaseModel):
-    email: str
-    password: str
-    role: str  # 'vendor' ou 'customer'
-    date_of_birth: date
 
 class UserOut(BaseModel):
     id: int
     email: str
-    role: str
-    date_of_birth: date
 
     class Config:
         orm_mode = True
@@ -25,25 +16,19 @@ class UserLogin(BaseModel):
 class VendorProfileUpdate(BaseModel):
     email: Optional[str] = None
     password: Optional[str] = None
-    date_of_birth: Optional[date] = None
     product: Optional[Literal["Bolas de Berlim", "Gelados", "Acess\u00f3rios"]] = None
-
-class VendorUpdate(BaseModel):
-    current_lat: float
-    current_lng: float
+    profile_photo: Optional[str] = None
 
 class VendorCreate(BaseModel):
     email: str
     password: str
-    date_of_birth: date
     product: Literal["Bolas de Berlim", "Gelados", "Acess\u00f3rios"]
+    profile_photo: str
 
 class VendorOut(BaseModel):
     id: int
     product: str
-    current_lat: float
-    current_lng: float
-    last_update: datetime
+    profile_photo: str
     user: UserOut
 
     class Config:


### PR DESCRIPTION
## Summary
- simplify README to describe vendor registration, login and profile updates
- remove location and user registration endpoints
- add profile photo field to vendor model
- adjust schemas and routes for new vendor-only workflow

## Testing
- `python -m py_compile backend/app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b60039ac832e8d90aefcf43741d9