### PR TITLE
Enable profile photo upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,11 +243,17 @@ import axios from 'axios';
 
 export default function App() {
   const register = () => {
-    axios.post('http://localhost:8000/vendors/', {
-      email: 'vendedor@example.com',
-      password: 'senha',
-      product: 'Bolas de Berlim',
-      profile_photo: 'foto.png'
+    const data = new FormData();
+    data.append('email', 'vendedor@example.com');
+    data.append('password', 'senha');
+    data.append('product', 'Bolas de Berlim');
+    data.append('profile_photo', {
+      uri: 'caminho/para/foto.png',
+      name: 'foto.png',
+      type: 'image/png',
+    });
+    axios.post('http://localhost:8000/vendors/', data, {
+      headers: { 'Content-Type': 'multipart/form-data' },
     });
   };
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,13 @@
 # main.py - aplicação FastAPI com rotas principais
 
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import FastAPI, Depends, HTTPException, UploadFile, File, Form
 from sqlalchemy.orm import Session
 from passlib.context import CryptContext
 from . import models, schemas
 from .database import SessionLocal, engine
+import os
+import shutil
+from uuid import uuid4
 
 # Criar as tabelas
 models.Base.metadata.create_all(bind=engine)
@@ -14,6 +17,10 @@ app = FastAPI()
 
 # Contexto para hash de password
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# Diretório para armazenar as fotos de perfil
+PROFILE_PHOTO_DIR = "profile_photos"
+os.makedirs(PROFILE_PHOTO_DIR, exist_ok=True)
 
 # --------------------------
 # Dependência para obter a sessão
@@ -42,23 +49,37 @@ def login(credentials: schemas.UserLogin, db: Session = Depends(get_db)):
 # Rota de registro de vendedor
 # --------------------------
 @app.post("/vendors/", response_model=schemas.VendorOut)
-def create_vendor(vendor: schemas.VendorCreate, db: Session = Depends(get_db)):
-    db_user = db.query(models.User).filter(models.User.email == vendor.email).first()
+async def create_vendor(
+    email: str = Form(...),
+    password: str = Form(...),
+    product: str = Form(...),
+    profile_photo: UploadFile = File(...),
+    db: Session = Depends(get_db),
+):
+    db_user = db.query(models.User).filter(models.User.email == email).first()
     if db_user:
         raise HTTPException(status_code=400, detail="Email already registered")
-    hashed_password = pwd_context.hash(vendor.password)
+    hashed_password = pwd_context.hash(password)
     new_user = models.User(
-        email=vendor.email,
+        email=email,
         hashed_password=hashed_password,
         role="vendor",
     )
     db.add(new_user)
     db.commit()
     db.refresh(new_user)
+
+    # Guardar a foto de perfil em disco
+    ext = os.path.splitext(profile_photo.filename)[1]
+    file_name = f"{uuid4().hex}{ext}"
+    file_path = os.path.join(PROFILE_PHOTO_DIR, file_name)
+    with open(file_path, "wb") as buffer:
+        shutil.copyfileobj(profile_photo.file, buffer)
+
     new_vendor = models.Vendor(
         user_id=new_user.id,
-        product=vendor.product,
-        profile_photo=vendor.profile_photo,
+        product=product,
+        profile_photo=file_path,
     )
     db.add(new_vendor)
     db.commit()
@@ -69,23 +90,31 @@ def create_vendor(vendor: schemas.VendorCreate, db: Session = Depends(get_db)):
 # Rota para atualizar perfil do vendedor
 # --------------------------
 @app.put("/vendors/{vendor_id}/profile", response_model=schemas.VendorOut)
-def update_vendor_profile(
+async def update_vendor_profile(
     vendor_id: int,
-    update: schemas.VendorProfileUpdate,
+    email: str = Form(None),
+    password: str = Form(None),
+    product: str = Form(None),
+    profile_photo: UploadFile = File(None),
     db: Session = Depends(get_db),
 ):
     vendor = db.query(models.Vendor).filter(models.Vendor.id == vendor_id).first()
     if not vendor:
         raise HTTPException(status_code=404, detail="Vendor not found")
     user = vendor.user
-    if update.email is not None:
-        user.email = update.email
-    if update.password is not None:
-        user.hashed_password = pwd_context.hash(update.password)
-    if update.product is not None:
-        vendor.product = update.product
-    if update.profile_photo is not None:
-        vendor.profile_photo = update.profile_photo
+    if email is not None:
+        user.email = email
+    if password is not None:
+        user.hashed_password = pwd_context.hash(password)
+    if product is not None:
+        vendor.product = product
+    if profile_photo is not None:
+        ext = os.path.splitext(profile_photo.filename)[1]
+        file_name = f"{uuid4().hex}{ext}"
+        file_path = os.path.join(PROFILE_PHOTO_DIR, file_name)
+        with open(file_path, "wb") as buffer:
+            shutil.copyfileobj(profile_photo.file, buffer)
+        vendor.profile_photo = file_path
     db.commit()
     db.refresh(vendor)
     return vendor

--- a/mobile/screens/RegisterScreen.js
+++ b/mobile/screens/RegisterScreen.js
@@ -11,11 +11,19 @@ const [error, setError] = useState(null);
 
 const register = async () => {
   try {
-    await axios.post('http://10.0.2.2:8000/vendors/', {
-      email,
-      password,
-      product,
-      profile_photo: profilePhoto,
+    const data = new FormData();
+    data.append('email', email);
+    data.append('password', password);
+    data.append('product', product);
+    if (profilePhoto) {
+      data.append('profile_photo', {
+        uri: profilePhoto,
+        name: 'profile.jpg',
+        type: 'image/jpeg',
+      });
+    }
+    await axios.post('http://10.0.2.2:8000/vendors/', data, {
+      headers: { 'Content-Type': 'multipart/form-data' },
     });
     navigation.navigate('Login');
   } catch (err) {


### PR DESCRIPTION
## Summary
- handle photo uploads as files in FastAPI
- save uploaded files on disk
- accept files in vendor update
- update React Native register screen to send FormData
- document the new API usage

## Testing
- `python3 -m py_compile backend/app/*.py`
- `npx -y eslint mobile/screens/RegisterScreen.js` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841675011f0832e81faf3b97fa107c0