### PR TITLE
Fix registration user loading and add vendor list

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -87,7 +87,20 @@ async def create_vendor(
     db.add(new_vendor)
     db.commit()
     db.refresh(new_vendor)
+    # Garantir que a relação com o utilizador está carregada antes de fechar a sessão
+    _ = new_vendor.user
     return new_vendor
+
+# --------------------------
+# Rota para listar vendedores
+# --------------------------
+@app.get("/vendors/", response_model=list[schemas.VendorOut])
+def list_vendors(db: Session = Depends(get_db)):
+    vendors = db.query(models.Vendor).all()
+    # Carregar relação com o utilizador para cada vendedor
+    for v in vendors:
+        _ = v.user
+    return vendors
 
 # --------------------------
 # Rota para atualizar perfil do vendedor


### PR DESCRIPTION
## Summary
- ensure user relation is loaded before returning vendor on registration
- add `/vendors/` GET endpoint for listing vendors

## Testing
- `python -m py_compile backend/app/main.py`
- `python -m py_compile backend/app/models.py`


------
https://chatgpt.com/codex/tasks/task_e_68417a6db54c832e83305496aaa53854