### PR TITLE
Add product picker to registration

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -19,6 +19,7 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "4.11.1",
     "expo-image-picker": "~16.1.4",
-    "@react-native-async-storage/async-storage": "2.1.2"
+    "@react-native-async-storage/async-storage": "2.1.2",
+    "@react-native-picker/picker": "2.4.10"
   }
 }

--- a/mobile/screens/RegisterScreen.js
+++ b/mobile/screens/RegisterScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, TextInput, Button, StyleSheet, Text, Image } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import * as ImagePicker from 'expo-image-picker';
 import axios from 'axios';
 
@@ -73,12 +74,16 @@ const register = async () => {
         onChangeText={setPassword}
       />
 
-      <TextInput
+      <Picker
+        selectedValue={product}
+        onValueChange={(itemValue) => setProduct(itemValue)}
         style={styles.input}
-        placeholder="Produto"
-        value={product}
-        onChangeText={setProduct}
-      />
+      >
+        <Picker.Item label="Selecione um produto" value="" />
+        <Picker.Item label="Bolas de Berlim" value="Bolas de Berlim" />
+        <Picker.Item label="Gelados" value="Gelados" />
+        <Picker.Item label="Acessórios" value="Acessórios" />
+      </Picker>
 
       <Button title="Escolher Foto de Perfil" onPress={pickImage} />
 


### PR DESCRIPTION
## Summary
- allow vendors to pick a product from a dropdown
- include `@react-native-picker/picker` dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684190154b8c832e86a6c4c864bc988d