### PR TITLE
Add location sharing to vendor dashboard

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -19,6 +19,7 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "4.11.1",
     "expo-image-picker": "~16.1.4",
+    "expo-location": "~16.4.1",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-picker/picker": "2.11.0"
   }

--- a/mobile/screens/DashboardScreen.js
+++ b/mobile/screens/DashboardScreen.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { View, TextInput, Button, StyleSheet, Text, Image } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import * as ImagePicker from 'expo-image-picker';
+import * as Location from 'expo-location';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
 
@@ -12,6 +13,8 @@ export default function DashboardScreen() {
   const [product, setProduct] = useState('');
   const [profilePhoto, setProfilePhoto] = useState(null);
   const [error, setError] = useState(null);
+  const [sharingLocation, setSharingLocation] = useState(false);
+  const [locationSub, setLocationSub] = useState(null);
 
   useEffect(() => {
     const loadVendor = async () => {
@@ -73,6 +76,47 @@ export default function DashboardScreen() {
     }
   };
 
+  const toggleLocation = async () => {
+    if (sharingLocation) {
+      if (locationSub) {
+        locationSub.remove();
+        setLocationSub(null);
+      }
+      setSharingLocation(false);
+    } else {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== 'granted') {
+        setError('Permissão de localização negada');
+        return;
+      }
+      const sub = await Location.watchPositionAsync(
+        {
+          accuracy: Location.Accuracy.High,
+          timeInterval: 10000,
+          distanceInterval: 10,
+        },
+        ({ coords }) => {
+          axios
+            .put(`http://10.0.2.2:8000/vendors/${vendor.id}/location`, {
+              lat: coords.latitude,
+              lng: coords.longitude,
+            })
+            .catch(err => console.log('Erro ao enviar localização:', err));
+        }
+      );
+      setLocationSub(sub);
+      setSharingLocation(true);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (locationSub) {
+        locationSub.remove();
+      }
+    };
+  }, [locationSub]);
+
   if (!vendor) {
     return (
       <View style={styles.container}>
@@ -118,6 +162,11 @@ export default function DashboardScreen() {
       )}
 
       <Button title="Atualizar" onPress={updateProfile} />
+
+      <Button
+        title={sharingLocation ? 'Desativar Localização' : 'Ativar Localização'}
+        onPress={toggleLocation}
+      />
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- enable expo-location in dependencies
- allow vendors to activate device location sharing on Dashboard screen

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841a7ef6bf4832ea04c253ed1819d9e