### PR TITLE
Refactor base API URL into config

### DIFF
--- a/mobile/config.js
+++ b/mobile/config.js
@@ -1,0 +1,2 @@
+export const BASE_URL = 'http://10.0.2.2:8000';
+

--- a/mobile/locationService.js
+++ b/mobile/locationService.js
@@ -1,6 +1,7 @@
 import * as Location from 'expo-location';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
+import { BASE_URL } from './config';
 
 let locationSubscription = null;
 
@@ -20,7 +21,7 @@ export const startLocationSharing = async (vendorId) => {
     },
     ({ coords }) => {
       axios
-        .put(`http://10.0.2.2:8000/vendors/${vendorId}/location`, {
+        .put(`${BASE_URL}/vendors/${vendorId}/location`, {
           lat: coords.latitude,
           lng: coords.longitude,
         })

--- a/mobile/screens/DashboardScreen.js
+++ b/mobile/screens/DashboardScreen.js
@@ -4,6 +4,7 @@ import { Picker } from '@react-native-picker/picker';
 import * as ImagePicker from 'expo-image-picker';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
+import { BASE_URL } from '../config';
 import {
   startLocationSharing,
   stopLocationSharing,
@@ -76,7 +77,7 @@ export default function DashboardScreen({ navigation }) {
       }
 
       const response = await axios.put(
-        `http://10.0.2.2:8000/vendors/${vendor.id}/profile`,
+        `${BASE_URL}/vendors/${vendor.id}/profile`,
         data,
         { headers: { 'Content-Type': 'multipart/form-data' } }
       );
@@ -130,7 +131,7 @@ export default function DashboardScreen({ navigation }) {
       ) : (
         vendor.profile_photo && (
           <Image
-            source={{ uri: `http://10.0.2.2:8000/${vendor.profile_photo}` }}
+            source={{ uri: `${BASE_URL}/${vendor.profile_photo}` }}
             style={styles.imagePreview}
           />
         )

--- a/mobile/screens/LoginScreen.js
+++ b/mobile/screens/LoginScreen.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { View, TextInput, Button, StyleSheet, Text } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
+import { BASE_URL } from '../config';
 
 export default function LoginScreen({ navigation }) {
   const [email, setEmail] = useState('');
@@ -10,7 +11,7 @@ export default function LoginScreen({ navigation }) {
 
   const login = async () => {
     try {
-      const response = await axios.post('http://10.0.2.2:8000/login', {
+      const response = await axios.post(`${BASE_URL}/login`, {
         email,
         password,
       });

--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -3,6 +3,7 @@ import { View, StyleSheet, TouchableOpacity, Text } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import MapView, { Marker } from 'react-native-maps';
 import axios from 'axios';
+import { BASE_URL } from '../config';
 import {
   startLocationSharing,
   stopLocationSharing,
@@ -16,7 +17,7 @@ export default function MapScreen({ navigation }) {
   useEffect(() => {
     const fetchVendors = () => {
       axios
-        .get('http://10.0.2.2:8000/vendors/')
+        .get(`${BASE_URL}/vendors/`)
         .then((res) => setVendors(res.data))
         .catch((err) => console.log('Erro ao buscar vendedores:', err));
     };

--- a/mobile/screens/RegisterScreen.js
+++ b/mobile/screens/RegisterScreen.js
@@ -3,6 +3,7 @@ import { View, TextInput, Button, StyleSheet, Text, Image } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import * as ImagePicker from 'expo-image-picker';
 import axios from 'axios';
+import { BASE_URL } from '../config';
 
 export default function RegisterScreen({ navigation }) {
 const [email, setEmail] = useState('');
@@ -38,7 +39,7 @@ try {
     });
   }
 
-  await axios.post('http://10.0.2.2:8000/vendors/', data, {
+  await axios.post(`${BASE_URL}/vendors/`, data, {
     headers: { 'Content-Type': 'multipart/form-data' },
   });
 


### PR DESCRIPTION
## Summary
- centralize the API base URL in `mobile/config.js`
- use the shared constant in network requests

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841e8c38ddc832e96358a6db740e914