### PR TITLE
Add httpx to backend deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ uvicorn
 sqlalchemy
 psycopg2-binary
 python-dotenv
+passlib[bcrypt]
+httpx
 ```
 
 ### 2.2 Arquivo database.py

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy
 psycopg2-binary
 python-dotenv
 passlib[bcrypt]
+httpx


### PR DESCRIPTION
## Summary
- install httpx for tests via backend requirements
- mention new dependency in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68471b674b14832ea110ceb5e7c96ea3