### PR TITLE
Disable React Native new architecture

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "userInterfaceStyle": "light",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",


### PR DESCRIPTION
## Summary
- turn off new architecture in mobile/app.json

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run android` *(fails: `expo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68471b7110bc832eab818d7de1b97e92