### PR TITLE
Hide google watermark on map

### DIFF
--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -85,6 +85,7 @@ export default function MapScreen({ navigation }) {
         ref={mapRef}
         style={styles.map}
         mapType="none"
+        legalLabelInsets={{ bottom: -100, right: -100 }}
         initialRegion={{
           latitude: 38.736946,
           longitude: -9.142685,


### PR DESCRIPTION
## Summary
- hide Google legal label so only OpenStreetMap tiles show

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68475ff51260832e90eaed36daa1d4b5