### PR TITLE
Fix map provider causing TypeError

### DIFF
--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -86,7 +86,7 @@ export default function MapScreen({ navigation }) {
     <View style={styles.container}>
       {/* (em português) Mapa com OpenStreetMap como base e marcadores dos vendedores */}
       <MapView
-        provider={null} // <- força sem Google Maps
+        provider={PROVIDER_DEFAULT}
         style={styles.map}
         mapType="none"
         legalLabelInsets={{ bottom: -100, right: -100 }}


### PR DESCRIPTION
## Summary
- fix map provider on MapScreen

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684765943e88832ea63ee765231d89c7