### PR TITLE
Switch to OpenStreetMap via Leaflet

### DIFF
--- a/mobile/LeafletMap.js
+++ b/mobile/LeafletMap.js
@@ -1,0 +1,54 @@
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import { StyleSheet } from 'react-native';
+import { WebView } from 'react-native-webview';
+
+const LeafletMap = forwardRef(({ markers = [] }, ref) => {
+  const webviewRef = useRef(null);
+  const html = `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link
+          rel="stylesheet"
+          href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+        />
+        <style>
+          html, body, #map { height: 100%; margin: 0; padding: 0; }
+        </style>
+      </head>
+      <body>
+        <div id="map"></div>
+        <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+        <script>
+          var map = L.map('map').setView([38.736946, -9.142685], 13);
+          L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19 }).addTo(map);
+          var markers = ${JSON.stringify(markers)};
+          markers.forEach(function(m) {
+            L.marker([m.latitude, m.longitude]).addTo(map).bindPopup(m.title || '');
+          });
+          window.setView = function(lat, lng) { map.setView([lat, lng], 15); };
+        </script>
+      </body>
+    </html>`;
+
+  useImperativeHandle(ref, () => ({
+    setView: (lat, lng) => {
+      if (webviewRef.current) {
+        const js = `window.setView(${lat}, ${lng}); true;`;
+        webviewRef.current.injectJavaScript(js);
+      }
+    },
+  }));
+
+  return (
+    <WebView
+      ref={webviewRef}
+      originWhitelist={["*"]}
+      source={{ html }}
+      style={StyleSheet.absoluteFill}
+    />
+  );
+});
+
+export default LeafletMap;

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -18,7 +18,7 @@
         "expo-location": "~18.1.5",
         "react": "19.0.0",
         "react-native": "0.79.3",
-        "react-native-maps": "1.17.1",
+        "react-native-webview": "13.8.3",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1"
       },
@@ -7005,28 +7005,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/react-native-maps": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.17.1.tgz",
-      "integrity": "sha512-Fm91uAOJ2QURtKPhxRfmIW37zGSxZqbW5WkxSSEiuHg7k+z801GniyLo1qnCtFZ5zv3ie1vPg69Q8V93wZI9zQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "^7946.0.13"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": ">= 17.0.1",
-        "react-native": ">= 0.64.3",
-        "react-native-web": ">= 0.11"
-      },
-      "peerDependenciesMeta": {
-        "react-native-web": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-native-safe-area-context": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -19,7 +19,7 @@
     "expo-location": "~18.1.5",
     "react": "19.0.0",
     "react-native": "0.79.3",
-    "react-native-maps": "1.17.1",
+    "react-native-webview": "13.8.3",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1"
   },

--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -10,7 +10,8 @@ import {
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import MapView, { Marker, UrlTile, PROVIDER_DEFAULT } from 'react-native-maps';
+// Substituímos react-native-maps por um componente baseado em WebView com Leaflet
+import LeafletMap from '../LeafletMap';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import {
@@ -84,43 +85,15 @@ export default function MapScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
-      {/* (em português) Mapa com OpenStreetMap como base e marcadores dos vendedores */}
-      <MapView
-        provider={PROVIDER_DEFAULT}
-        style={styles.map}
-        mapType="none"
-        legalLabelInsets={{ bottom: -100, right: -100 }}
-        initialRegion={{
-          latitude: 38.736946,
-          longitude: -9.142685,
-          latitudeDelta: 0.05,
-          longitudeDelta: 0.05,
-        }}
+      {/* (em português) Mapa usando Leaflet via WebView */}
+      <LeafletMap
         ref={mapRef}
-      >
-        {/* (em português) Camadas do OpenStreetMap */}
-        <UrlTile
-          urlTemplate="https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
-          maximumZ={19}
-          flipY={false}
-        />
-
-        {/* (em português) Marcadores dos vendedores */}
-        {filteredVendors.map((vendor) => {
-          if (!vendor?.current_lat || !vendor?.current_lng) return null;
-          return (
-            <Marker
-              key={vendor.id}
-              coordinate={{
-                latitude: vendor.current_lat,
-                longitude: vendor.current_lng,
-              }}
-              title={vendor.user?.name || 'Vendedor'}
-              description={vendor.product || ''}
-            />
-          );
-        })}
-      </MapView>
+        markers={filteredVendors.map((v) => ({
+          latitude: v.current_lat,
+          longitude: v.current_lng,
+          title: v.user?.name || 'Vendedor',
+        }))}
+      />
 
       {/* (em português) Filtros e lista de vendedores */}
       <View style={styles.filterContainer}>
@@ -142,14 +115,9 @@ export default function MapScreen({ navigation }) {
             <TouchableOpacity
               style={styles.vendorItem}
               onPress={() =>
-                mapRef.current?.animateToRegion(
-                  {
-                    latitude: item.current_lat,
-                    longitude: item.current_lng,
-                    latitudeDelta: 0.01,
-                    longitudeDelta: 0.01,
-                  },
-                  1000
+                mapRef.current?.setView(
+                  item.current_lat,
+                  item.current_lng
                 )
               }
             >
@@ -192,7 +160,6 @@ export default function MapScreen({ navigation }) {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  map: { flex: 1 },
   filterContainer: {
     position: 'absolute',
     top: 40,


### PR DESCRIPTION
## Summary
- drop `react-native-maps` dependency
- use Leaflet inside a `WebView` to show the map
- update vendor list item to center the map using the new map component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68476848f118832e9248cf63e6b307e8