### PR TITLE
Fix map filter overlap

### DIFF
--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -162,7 +162,9 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
   filterContainer: {
     position: 'absolute',
-    top: 40,
+    // Colocamos a barra de filtros mais abaixo para nao sobrepor os botoes de
+    // zoom do Leaflet
+    top: 100,
     left: 10,
     right: 10,
     backgroundColor: '#fff',


### PR DESCRIPTION
## Summary
- move vendor filter bar down to avoid overlap with zoom controls

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68494b98bd18832ebab5fb45ab6cf7a8