### PR TITLE
Fix vendor profile update

### DIFF
--- a/mobile/config.js
+++ b/mobile/config.js
@@ -1,1 +1,10 @@
-export const BASE_URL = 'http://10.0.2.2:8000';
+import Constants from 'expo-constants';
+
+// Allow BASE_URL to be configured via environment variable or Expo config
+const envUrl =
+  process.env.BASE_URL ||
+  process.env.EXPO_PUBLIC_BASE_URL ||
+  Constants.expoConfig?.extra?.BASE_URL;
+
+// Default to Android emulator loopback
+export const BASE_URL = envUrl || 'http://10.0.2.2:8000';

--- a/mobile/screens/DashboardScreen.js
+++ b/mobile/screens/DashboardScreen.js
@@ -104,7 +104,8 @@ export default function DashboardScreen({ navigation }) {
         url: `${BASE_URL}/vendors/${vendor.id}/profile`,
         data: data,
         headers: {
-          'Accept': 'application/json',
+          Accept: 'application/json',
+          'Content-Type': 'multipart/form-data',
         },
       });
 


### PR DESCRIPTION
## Summary
- support BASE_URL override via Expo config
- send multipart-form data for PATCH vendor profile updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68496119024c832e87d69f259ba0ef0b