### PR TITLE
Aumenta tamanho máximo da lista de vendedores

### DIFF
--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -181,7 +181,8 @@ const styles = StyleSheet.create({
     padding: 6,
   },
   picker: { backgroundColor: '#eee', marginBottom: 4 },
-  vendorList: { maxHeight: 80 },
+  // Aumentamos a altura máxima para mostrar mais vendedores sem precisar rolar
+  vendorList: { maxHeight: 200 },
   vendorItem: {
     paddingVertical: 4,
     borderBottomWidth: 1,


### PR DESCRIPTION
## Summary
- aumentar maxHeight do estilo `vendorList` para exibir mais itens no MapScreen

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68498d096efc832eaf8d84ecdc38ca7d