### PR TITLE
Add mobile WebSocket updates

### DIFF
--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -15,6 +15,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import LeafletMap from '../LeafletMap';
 import axios from 'axios';
 import { BASE_URL } from '../config';
+import { subscribe as subscribeLocations } from '../socketService';
 import {
   startLocationSharing,
   stopLocationSharing,
@@ -76,6 +77,18 @@ export default function MapScreen({ navigation }) {
 
     return unsubscribe;
   }, [navigation]);
+
+  // Subscrição ao WebSocket para atualizações de localização
+  useEffect(() => {
+    const unsubscribe = subscribeLocations(({ vendor_id, lat, lng }) => {
+      setVendors((prev) =>
+        prev.map((v) =>
+          v.id === vendor_id ? { ...v, current_lat: lat, current_lng: lng } : v
+        )
+      );
+    });
+    return unsubscribe;
+  }, []);
 
   const activeVendors = vendors.filter(
     (v) => v?.current_lat != null && v?.current_lng != null

--- a/mobile/socketService.js
+++ b/mobile/socketService.js
@@ -1,0 +1,67 @@
+import { BASE_URL } from './config';
+
+let socket = null;
+let reconnectTimeout = null;
+const listeners = new Set();
+
+function getWsUrl() {
+  // Convert http(s):// to ws(s)://
+  return `${BASE_URL.replace(/^http/, 'ws')}/ws/locations`;
+}
+
+function connect() {
+  if (socket) return;
+  const url = getWsUrl();
+  try {
+    socket = new WebSocket(url);
+  } catch (err) {
+    console.log('Erro ao criar WebSocket:', err);
+    scheduleReconnect();
+    return;
+  }
+
+  socket.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      listeners.forEach((cb) => cb(data));
+    } catch (e) {
+      console.log('Erro ao processar mensagem WS:', e);
+    }
+  };
+
+  socket.onclose = () => {
+    socket = null;
+    scheduleReconnect();
+  };
+
+  socket.onerror = () => {
+    // Force close so onclose handles reconnection
+    socket?.close();
+  };
+}
+
+function scheduleReconnect() {
+  if (reconnectTimeout) return;
+  reconnectTimeout = setTimeout(() => {
+    reconnectTimeout = null;
+    connect();
+  }, 3000);
+}
+
+export function subscribe(callback) {
+  listeners.add(callback);
+  connect();
+  return () => listeners.delete(callback);
+}
+
+export function disconnect() {
+  if (socket) {
+    socket.close();
+    socket = null;
+  }
+  if (reconnectTimeout) {
+    clearTimeout(reconnectTimeout);
+    reconnectTimeout = null;
+  }
+  listeners.clear();
+}


### PR DESCRIPTION
## Summary
- add a reusable socketService to manage reconnection to `/ws/locations`
- subscribe MapScreen to WebSocket updates so vendor positions refresh automatically

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6849a74f26dc832eab85cc51be50b0ff