### PR TITLE
Fix BASE_URL override in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,19 @@ Ou defina em `app.json`:
 
 Escolha a URL apropriada conforme estiver a testar em emuladores ou dispositivos reais.
 
+### 3.4.1 Build do APK para dispositivo
+
+Ao gerar o APK com `eas build` o endereço do backend também precisa estar definido.
+Use a mesma variável `EXPO_PUBLIC_BASE_URL` (ou a chave `expo.extra.BASE_URL` no
+`app.json`) apontando para o servidor acessível pelo aparelho:
+
+```bash
+EXPO_PUBLIC_BASE_URL=https://ss-app-jptj.onrender.com \
+  eas build -p android --profile production
+```
+
+Assim o aplicativo instalado num dispositivo físico comunica-se com o backend correto.
+
 
 
 ### 3.5 Funcionalidades adicionais

--- a/mobile/config.js
+++ b/mobile/config.js
@@ -6,5 +6,5 @@ const envUrl =
   process.env.EXPO_PUBLIC_BASE_URL ||
   Constants.expoConfig?.extra?.BASE_URL;
 
-// Default to Android emulator loopback
-export const BASE_URL = "https://ss-app-jptj.onrender.com"
+// Default to Android emulator loopback if no env variable is provided
+export const BASE_URL = envUrl || 'http://10.0.2.2:8000';


### PR DESCRIPTION
## Summary
- allow mobile BASE_URL to respect env variables again
- document how to set the base URL when building with EAS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684a96bbfc20832e87930b58f91c90cd