### PR TITLE
Fix default DB configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install -r backend/requirements.txt
 
 1. Instale o PostgreSQL.
 2. Crie uma base de dados chamada `beach_vendors` e um utilizador com permissões.
-3. Copie o arquivo `.env.example` para `.env` e defina `DATABASE_URL` com as suas credenciais. Opcionalmente ajuste `EXPO_PUBLIC_BASE_URL`.
+3. Copie o arquivo `.env.example` para `.env` e defina `DATABASE_URL` com as suas credenciais. Caso a variável não seja definida o backend usa uma base SQLite local. Opcionalmente ajuste `EXPO_PUBLIC_BASE_URL`.
 
 ```bash
 cp .env.example .env

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -11,8 +11,15 @@ load_dotenv()  # Isto carrega o .env
 # Obter a URL da base de dados das variáveis de ambiente
 DATABASE_URL = os.getenv("DATABASE_URL")
 
+# Se a variável não estiver definida, usa uma base SQLite local para facilitar
+if not DATABASE_URL:
+    DATABASE_URL = "sqlite:///./app.db"
+    connect_args = {"check_same_thread": False}
+else:
+    connect_args = {}
+
 # Criar o motor de conexão
-engine = create_engine(DATABASE_URL)
+engine = create_engine(DATABASE_URL, **connect_args)
 
 # Criar sessão de acesso ao banco
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
## Summary
- add SQLite fallback for local development
- document DATABASE_URL fallback in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684ab142e048832e9f110b1f69d4ff9e