### PR TITLE
Implement email confirmation and password reset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Example environment variables
+DATABASE_URL=postgresql://user:pass@localhost/beach_vendors
+SECRET_KEY=changeme
+# Stripe optional
+STRIPE_API_KEY=
+STRIPE_PRICE_ID=
+STRIPE_WEBHOOK_SECRET=
+SUCCESS_URL=https://example.com/success
+CANCEL_URL=https://example.com/cancel
+# Email settings (Gmail)
+SMTP_USER=sunnysales.geral@gmail.com
+SMTP_PASSWORD=
+SMTP_SERVER=smtp.gmail.com
+SMTP_PORT=587

--- a/README.md
+++ b/README.md
@@ -234,6 +234,19 @@ O backend ficará disponível em `http://localhost:8000`.
 
 O arquivo `backend/app/main.py` agora configura o middleware `CORSMiddleware` para permitir que o aplicativo móvel aceda ao backend durante o desenvolvimento. Foi também criado um endpoint WebSocket (`/ws/locations`) que emite atualizações de localização dos vendedores em tempo real para todos os clientes conectados.
 
+### 2.8 Envio de e-mails
+
+Para confirmar contas e redefinir senhas a aplicação envia e-mails via SMTP. Defina as variáveis abaixo (pode usar uma conta Gmail com palavra‑passe de aplicativo):
+
+```env
+SMTP_USER=sunnysales.geral@gmail.com
+SMTP_PASSWORD=<sua_app_password>
+SMTP_SERVER=smtp.gmail.com
+SMTP_PORT=587
+```
+
+Se não definir `SMTP_USER` e `SMTP_PASSWORD` o backend apenas ignora o envio dos e-mails.
+
 ## 3. Frontend (React Native)
 
 ### 3.1 Instalação de dependências

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -20,6 +20,10 @@ class Vendor(Base):
     current_lng = Column(Float, nullable=True)
     subscription_active = Column(Boolean, default=False)
     subscription_valid_until = Column(DateTime, nullable=True)
+    email_confirmed = Column(Boolean, default=False)
+    confirmation_token = Column(String, nullable=True, index=True)
+    password_reset_token = Column(String, nullable=True, index=True)
+    password_reset_expires = Column(DateTime, nullable=True)
 
     reviews = relationship("Review", back_populates="vendor")
 


### PR DESCRIPTION
## Summary
- add SMTP email settings and helper to send Gmail messages
- persist confirmation and reset tokens on Vendor model
- require confirmed email for login and token
- provide routes for confirming emails and resetting passwords
- document email setup in README
- add `.env.example` with Gmail config
- expand tests to cover new flows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685021d5794c832eb7ac4174b63b4feb