### PR TITLE
Remove pin color selection on registration

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -190,7 +190,6 @@ async def create_vendor(
     password: str = Form(...),
     product: str = Form(...),
     profile_photo: UploadFile = File(...),
-    pin_color: str = Form("#FF0000"),
     db: Session = Depends(get_db),
 ):
     db_vendor = db.query(models.Vendor).filter(models.Vendor.email == email).first()
@@ -213,7 +212,7 @@ async def create_vendor(
         hashed_password=hashed_password,
         product=product,
         profile_photo=public_path,
-        pin_color=pin_color,
+        pin_color="#FF0000",
         confirmation_token=token_urlsafe(32),
     )
     db.add(new_vendor)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -20,7 +20,6 @@ class VendorCreate(BaseModel):
     password: str
     product: Literal["Bolas de Berlim", "Gelados", "Acess\u00f3rios"]
     profile_photo: str
-    pin_color: Optional[str] = "#FF0000"
 
 class VendorOut(BaseModel):
     id: int

--- a/mobile/LeafletMap.js
+++ b/mobile/LeafletMap.js
@@ -19,12 +19,13 @@ const LeafletMap = forwardRef((props, ref) => {
           html, body, #map { height: 100%; margin: 0; padding: 0; }
           .custom-icon .gm-pin {
             position: relative;
-            width: 30px;
-            height: 30px;
+            width: 36px;
+            height: 36px;
             border-radius: 50% 50% 50% 0;
             transform: rotate(-45deg);
             overflow: hidden;
             background: white;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.3);
           }
           .custom-icon .gm-pin img {
             position: absolute;

--- a/mobile/screens/RegisterScreen.js
+++ b/mobile/screens/RegisterScreen.js
@@ -7,7 +7,7 @@ import {
   Text,
   Image,
   ActivityIndicator,
-  TouchableOpacity,
+  Alert,
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import * as ImagePicker from 'expo-image-picker';
@@ -19,11 +19,6 @@ export default function RegisterScreen({ navigation }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [product, setProduct] = useState('');
-  const [pinColor, setPinColor] = useState('#FF0000');
-  const colorOptions = [
-    '#FF0000', '#FFA500', '#FFFF00', '#008000', '#00FFFF',
-    '#0000FF', '#800080', '#FFC0CB', '#808080', '#000000',
-  ];
   const [profilePhoto, setProfilePhoto] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -55,7 +50,6 @@ export default function RegisterScreen({ navigation }) {
       data.append('email', email);
       data.append('password', password);
       data.append('product', product);
-      data.append('pin_color', pinColor);
 
       if (profilePhoto) {
         data.append('profile_photo', {
@@ -71,6 +65,10 @@ export default function RegisterScreen({ navigation }) {
         },
       });
 
+      Alert.alert(
+        'Registo efetuado',
+        'Verifique o seu e-mail para confirmar a conta.'
+      );
       navigation.navigate('Login');
     } catch (err) {
       console.error("Erro no registo:", err);
@@ -137,20 +135,6 @@ export default function RegisterScreen({ navigation }) {
         <Picker.Item label="Acessórios" value="Acessórios" />
       </Picker>
 
-      <Text style={styles.pinColorLabel}>Cor do contorno do pin</Text>
-      <View style={styles.colorOptions}>
-        {colorOptions.map((c) => (
-          <TouchableOpacity
-            key={c}
-            onPress={() => setPinColor(c)}
-            style={[
-              styles.colorOption,
-              { backgroundColor: c },
-              pinColor === c && styles.colorOptionSelected,
-            ]}
-          />
-        ))}
-      </View>
 
       <Button title="Escolher Foto de Perfil" onPress={pickImage} />
 
@@ -189,16 +173,5 @@ const styles = StyleSheet.create({
     borderRadius: 50,
     alignSelf: 'center',
   },
-  pinColorLabel: { alignSelf: 'flex-start', marginBottom: 4 },
-  colorOptions: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 12 },
-  colorOption: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    marginRight: 8,
-    marginBottom: 8,
-    borderWidth: 1,
-    borderColor: '#000',
-  },
-  colorOptionSelected: { borderWidth: 3 },
+  // estilos removidos de seleção de cor do pin
 });

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,7 +41,6 @@ def register_vendor(client, email="vendor@example.com", password="secret", name=
         "email": email,
         "password": password,
         "product": "Bolas de Berlim",
-        "pin_color": "#FF0000",
     }
     files = {"profile_photo": ("test.png", b"fakeimage", "image/png")}
     return client.post("/vendors/", data=data, files=files)


### PR DESCRIPTION
## Summary
- remove `pin_color` param from vendor registration API
- adjust `VendorCreate` schema
- simplify mobile registration screen and show confirmation message
- modernize pin style in Leaflet map
- update tests for new API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6850389881f8832e9cd5147a63013166