### PR TITLE
Add vendor movement simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,10 +356,21 @@ O aplicativo móvel inclui agora uma tela de detalhes para cada vendedor. Nela �
 
 Adicionalmente, quando um vendedor ativo estiver num raio de aproximadamente 500 metros do utilizador, o app envia uma notificação local (usa `expo-notifications`). Certifique-se de executar `npm install` para instalar esta dependência antes de iniciar o Expo.
 
+## 4. Simulação automática de movimento
 
-Adicionalmente, quando um vendedor ativo estiver num raio de aproximadamente 500 metros do utilizador, o app envia uma notificação local (usa `expo-notifications`). Certifique-se de executar `npm install` para instalar esta dependência antes de iniciar o Expo.
+Para testar o backend é possível simular o deslocamento de um vendedor existente.
+O script `scripts/simulate_movement.py` envia atualizações de localização para o
+servidor. Defina as credenciais do vendedor através das variáveis de ambiente
+`VENDOR_EMAIL` e `VENDOR_PASSWORD` e execute:
 
-## 4. Considerações finais
+```bash
+python scripts/simulate_movement.py
+```
+
+Por padrão o script usa `BASE_URL=http://localhost:8000` e `VENDOR_ID=1`, mas
+estes valores podem ser sobrepostos via variáveis de ambiente.
+
+## 5. Considerações finais
 
 * Este README fornece um guia inicial. Você pode expandir o backend com autenticação JWT e aprimorar o frontend conforme necessário.
 * Use o Visual Studio Code para editar os arquivos e acompanhar o desenvolvimento.

--- a/scripts/simulate_movement.py
+++ b/scripts/simulate_movement.py
@@ -1,0 +1,39 @@
+import os
+import time
+import httpx
+
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:8000")
+VENDOR_ID = int(os.environ.get("VENDOR_ID", "1"))
+EMAIL = os.environ.get("VENDOR_EMAIL")
+PASSWORD = os.environ.get("VENDOR_PASSWORD")
+
+if not EMAIL or not PASSWORD:
+    raise SystemExit("Please set VENDOR_EMAIL and VENDOR_PASSWORD environment variables")
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        # obtain token
+        resp = await client.post(f"{BASE_URL}/token", json={"email": EMAIL, "password": PASSWORD})
+        resp.raise_for_status()
+        token = resp.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # start route
+        await client.post(f"{BASE_URL}/vendors/{VENDOR_ID}/routes/start", headers=headers)
+
+        lat, lng = 40.0, -8.0
+        for _ in range(20):
+            await client.put(
+                f"{BASE_URL}/vendors/{VENDOR_ID}/location",
+                json={"lat": lat, "lng": lng},
+                headers=headers,
+            )
+            lat += 0.0005
+            lng += 0.0005
+            time.sleep(1)
+
+        await client.post(f"{BASE_URL}/vendors/{VENDOR_ID}/routes/stop", headers=headers)
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a simple script that sends location updates to simulate vendor movement
- document the simulator in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68504983b7d4832eb6a5bf532804a5fd