### PR TITLE
Move EAS config to repo root

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -11,7 +11,8 @@
         "buildType": "apk"
       },
       "node": "18.18.0",
-      "installCommand": "npm install"
+      "installCommand": "npm install",
+      "appRoot": "mobile"
     },
     "preview": {
       "distribution": "internal",
@@ -19,7 +20,8 @@
         "buildType": "apk"
       },
       "node": "18.18.0",
-      "installCommand": "npm install"
+      "installCommand": "npm install",
+      "appRoot": "mobile"
     },
     "production": {
       "developmentClient": false,
@@ -28,7 +30,8 @@
         "buildType": "apk"
       },
       "node": "18.18.0",
-      "installCommand": "npm install"
+      "installCommand": "npm install",
+      "appRoot": "mobile"
     }
   }
 }


### PR DESCRIPTION
## Summary
- move `eas.json` to repository root
- specify `appRoot` so EAS builds the app in the `mobile` folder

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68516ee5b970832ea2a3b547fdd513b0