### PR TITLE
Add stub for mobile eas.json

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,37 @@
+{
+  "cli": {
+    "version": ">=3.0.0",
+    "appVersionSource": "local"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      },
+      "node": "18.18.0",
+      "installCommand": "npm install",
+      "appRoot": "mobile"
+    },
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      },
+      "node": "18.18.0",
+      "installCommand": "npm install",
+      "appRoot": "mobile"
+    },
+    "production": {
+      "developmentClient": false,
+      "distribution": "store",
+      "android": {
+        "buildType": "apk"
+      },
+      "node": "18.18.0",
+      "installCommand": "npm install",
+      "appRoot": "mobile"
+    }
+  }
+}

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -1,34 +1,3 @@
 {
-  "cli": {
-    "version": ">=3.0.0",
-    "appVersionSource": "local"
-  },
-  "build": {
-    "development": {
-      "developmentClient": true,
-      "distribution": "internal",
-      "android": {
-        "buildType": "apk"
-      },
-      "node": "18.18.0",
-      "installCommand": "npm install"
-    },
-    "preview": {
-      "distribution": "internal",
-      "android": {
-        "buildType": "apk"
-      },
-      "node": "18.18.0",
-      "installCommand": "npm install"
-    },
-    "production": {
-      "developmentClient": false,
-      "distribution": "store",
-      "android": {
-        "buildType": "apk"
-      },
-      "node": "18.18.0",
-      "installCommand": "npm install"
-    }
-  }
+  "extends": "../eas.json"
 }


### PR DESCRIPTION
## Summary
- add `mobile/eas.json` that extends the root EAS config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68516ee5b970832ea2a3b547fdd513b0