### PR TITLE
Add client profile photo to review payloads

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -819,6 +819,10 @@ def create_review(
     db.add(new_rev)
     db.commit()
     db.refresh(new_rev)
+    new_rev.client_name = new_rev.client.name if new_rev.client else None
+    new_rev.client_profile_photo = (
+        new_rev.client.profile_photo if new_rev.client else None
+    )
     return new_rev
 
 
@@ -831,6 +835,7 @@ def list_reviews(vendor_id: int, db: Session = Depends(get_db)):
     )
     for r in reviews:
         r.client_name = r.client.name if r.client else None
+        r.client_profile_photo = r.client.profile_photo if r.client else None
     return reviews
 
 
@@ -854,6 +859,8 @@ def respond_review(
     review.response = data.response
     db.commit()
     db.refresh(review)
+    review.client_name = review.client.name if review.client else None
+    review.client_profile_photo = review.client.profile_photo if review.client else None
     return review
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -68,6 +68,7 @@ class ReviewOut(BaseModel):
     id: int
     vendor_id: int
     client_name: Optional[str] = None
+    client_profile_photo: Optional[str] = None
     rating: int
     comment: Optional[str] = None
     response: Optional[str] = None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -235,12 +235,16 @@ def test_reviews_endpoints(client):
     assert resp.status_code == 200
     review = resp.json()
     assert review["rating"] == 4
+    assert review["client_profile_photo"] is not None
 
     # list reviews
     resp = client.get(f"/vendors/{vendor_id}/reviews")
     assert resp.status_code == 200
     reviews = resp.json()
-    assert len(reviews) == 1 and reviews[0]["comment"] == "Bom" and reviews[0]["client_name"] == "Client"
+    assert len(reviews) == 1
+    assert reviews[0]["comment"] == "Bom"
+    assert reviews[0]["client_name"] == "Client"
+    assert reviews[0]["client_profile_photo"] is not None
 
 
 def test_review_response_and_delete(client):
@@ -264,7 +268,9 @@ def test_review_response_and_delete(client):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
-    assert resp.json()["response"] == "ok"
+    resp_json = resp.json()
+    assert resp_json["response"] == "ok"
+    assert resp_json["client_profile_photo"] is not None
 
     resp = client.delete(
         f"/vendors/{vendor_id}/reviews/{review['id']}",


### PR DESCRIPTION
## Summary
- expose `client_profile_photo` in review API responses
- test review APIs return reviewer profile photo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685afbb2f14c832eb8bf829059dacb0b