### PR TITLE
Add customer dashboard menus

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -19,6 +19,8 @@ import TermsScreen from './screens/TermsScreen';
 import PaidWeeksScreen from './screens/PaidWeeksScreen';
 import ForgotPasswordScreen from './screens/ForgotPasswordScreen';
 import AccountSettingsScreen from './screens/AccountSettingsScreen';
+import ManageAccountScreen from './screens/ManageAccountScreen';
+import AboutScreen from './screens/AboutScreen';
 import { theme } from './theme';
 import t from './i18n';
 
@@ -53,6 +55,8 @@ export default function App() {
           <Stack.Screen name="RouteDetail" component={RouteDetailScreen} options={{ title: 'Trajeto' }} />
           <Stack.Screen name="Terms" component={TermsScreen} options={{ title: 'Termos' }} />
           <Stack.Screen name="AccountSettings" component={AccountSettingsScreen} options={{ title: t('accountSettingsTitle') }} />
+          <Stack.Screen name="ManageAccount" component={ManageAccountScreen} options={{ title: 'Definições' }} />
+          <Stack.Screen name="About" component={AboutScreen} options={{ title: 'Sobre/Ajuda' }} />
         </Stack.Navigator>
       </NavigationContainer>
     </PaperProvider>

--- a/mobile/favoritesService.js
+++ b/mobile/favoritesService.js
@@ -25,3 +25,7 @@ export async function isFavorite(id) {
   const favs = await getFavorites();
   return favs.includes(id);
 }
+
+export async function clearFavorites() {
+  await AsyncStorage.removeItem(KEY);
+}

--- a/mobile/i18n.js
+++ b/mobile/i18n.js
@@ -15,6 +15,10 @@ const translations = {
     accountSettingsTitle: 'Account Settings',
     notificationsEnabled: 'Enable notifications',
     notificationRadius: 'Notification radius (m)',
+    clearFavorites: 'Clear favorites',
+    proximityMenu: 'Proximity notifications',
+    manageAccount: 'Manage account',
+    aboutHelp: 'About/Help',
   },
   pt: {
     statsTitle: 'Estatísticas',
@@ -29,6 +33,10 @@ const translations = {
     accountSettingsTitle: 'Definições de Conta',
     notificationsEnabled: 'Ativar notificações',
     notificationRadius: 'Raio para notificações (m)',
+    clearFavorites: 'Limpar favoritos',
+    proximityMenu: 'Notificações de proximidade',
+    manageAccount: 'Definições',
+    aboutHelp: 'Sobre/Ajuda',
   },
 };
 

--- a/mobile/screens/AboutScreen.js
+++ b/mobile/screens/AboutScreen.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, StyleSheet, Linking } from 'react-native';
+import { Button, Text } from 'react-native-paper';
+import { theme } from '../theme';
+
+export default function AboutScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Sobre e Ajuda</Text>
+      <Button
+        mode="outlined"
+        onPress={() => navigation.navigate('Terms')}
+        style={styles.button}
+      >
+        Termos e Condições
+      </Button>
+      <Button
+        mode="outlined"
+        onPress={() => Linking.openURL('mailto:suporte@sunnysales.com')}
+        style={styles.button}
+      >
+        Contactar Suporte
+      </Button>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16, backgroundColor: theme.colors.background },
+  title: { fontSize: 20, marginBottom: 16, textAlign: 'center' },
+  button: { marginBottom: 12 },
+});

--- a/mobile/screens/AccountSettingsScreen.js
+++ b/mobile/screens/AccountSettingsScreen.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { Switch, Text, TextInput } from 'react-native-paper';
+import { Switch, Text } from 'react-native-paper';
+import { Picker } from '@react-native-picker/picker';
 import {
   isNotificationsEnabled,
   setNotificationsEnabled,
@@ -30,11 +31,8 @@ export default function AccountSettingsScreen() {
   };
 
   const changeRadius = async (value) => {
-    setRadius(value);
-    const num = parseInt(value, 10);
-    if (!isNaN(num)) {
-      await setNotificationRadius(num);
-    }
+    setRadius(String(value));
+    await setNotificationRadius(value);
   };
 
   return (
@@ -44,14 +42,16 @@ export default function AccountSettingsScreen() {
         <Text>{t('notificationsEnabled')}</Text>
         <Switch value={enabled} onValueChange={toggleNotifications} />
       </View>
-      <TextInput
-        mode="outlined"
-        style={styles.input}
-        label={t('notificationRadius')}
-        keyboardType="numeric"
-        value={radius}
-        onChangeText={changeRadius}
-      />
+      <Text>{t('notificationRadius')}</Text>
+      <Picker
+        selectedValue={parseInt(radius, 10)}
+        onValueChange={changeRadius}
+        style={styles.picker}
+      >
+        <Picker.Item label="20" value={20} />
+        <Picker.Item label="50" value={50} />
+        <Picker.Item label="100" value={100} />
+      </Picker>
     </View>
   );
 }
@@ -60,5 +60,5 @@ const styles = StyleSheet.create({
   container: { flex: 1, padding: 16, backgroundColor: theme.colors.background },
   title: { fontSize: 20, marginBottom: 16 },
   row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 },
-  input: { marginBottom: 16 },
+  picker: { marginBottom: 16 },
 });

--- a/mobile/screens/ClientDashboardScreen.js
+++ b/mobile/screens/ClientDashboardScreen.js
@@ -5,7 +5,7 @@ import { Text, Button } from 'react-native-paper';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
 import { BASE_URL } from '../config';
-import { getFavorites } from '../favoritesService';
+import { getFavorites, clearFavorites } from '../favoritesService';
 import { theme } from '../theme';
 import t from '../i18n';
 
@@ -25,6 +25,11 @@ export default function ClientDashboardScreen({ navigation }) {
     } catch (e) {
       console.log('Erro ao carregar favoritos:', e);
     }
+  };
+
+  const clearAllFavorites = async () => {
+    await clearFavorites();
+    setFavorites([]);
   };
 
   const logout = async () => {
@@ -70,14 +75,35 @@ export default function ClientDashboardScreen({ navigation }) {
           );
         }}
       />
+      <Button mode="outlined" onPress={clearAllFavorites} style={styles.button}>
+        {t('clearFavorites')}
+      </Button>
       <Button
         mode="outlined"
         onPress={() => navigation.navigate('AccountSettings')}
-        style={styles.settings}
+        style={styles.button}
       >
-        {t('accountSettingsTitle')}
+        {t('proximityMenu')}
       </Button>
-      <Button mode="outlined" onPress={logout} style={styles.logout}>
+      <Button
+        mode="outlined"
+        onPress={() => navigation.navigate('ManageAccount')}
+        style={styles.button}
+      >
+        {t('manageAccount')}
+      </Button>
+      <Button
+        mode="outlined"
+        onPress={() => navigation.navigate('About')}
+        style={styles.button}
+      >
+        {t('aboutHelp')}
+      </Button>
+      <Button
+        mode="outlined"
+        onPress={logout}
+        style={styles.logout}
+      >
         Sair
       </Button>
     </View>
@@ -97,6 +123,6 @@ const styles = StyleSheet.create({
   image: { width: 40, height: 40, borderRadius: 20, marginRight: 8 },
   activePhoto: { borderWidth: 2, borderColor: 'green' },
   inactivePhoto: { borderWidth: 2, borderColor: 'red' },
-  settings: { marginTop: 20 },
+  button: { marginTop: 12 },
   logout: { marginTop: 20 },
 });

--- a/mobile/screens/ManageAccountScreen.js
+++ b/mobile/screens/ManageAccountScreen.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { View, StyleSheet, Alert } from 'react-native';
+import { Button, Text, TextInput } from 'react-native-paper';
+import { theme } from '../theme';
+
+export default function ManageAccountScreen() {
+  const [password, setPassword] = React.useState('');
+
+  const changePassword = () => {
+    Alert.alert('Funcionalidade indisponível');
+  };
+
+  const deleteAccount = () => {
+    Alert.alert('Funcionalidade indisponível');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Definições</Text>
+      <TextInput
+        mode="outlined"
+        label="Nova password"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+        style={styles.input}
+      />
+      <Button mode="contained" onPress={changePassword} style={styles.button}>
+        Alterar Password
+      </Button>
+      <Button mode="contained" onPress={deleteAccount} style={styles.button}>
+        Apagar Conta
+      </Button>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16, backgroundColor: theme.colors.background },
+  title: { fontSize: 20, marginBottom: 16, textAlign: 'center' },
+  input: { marginBottom: 16 },
+  button: { marginBottom: 12 },
+});


### PR DESCRIPTION
## Summary
- add ability to clear favorites
- expose proximity, account and help options on client dashboard
- show picker for notification radius
- add About and Manage Account screens
- wire up new screens in navigator
- update i18n strings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685b2a6f2a58832e8b86c632ff05e1d4