### PR TITLE
Translate UI to pt-PT

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -47,7 +47,7 @@ export default function App() {
           <Stack.Screen name="ClientLogin" component={ClientLoginScreen} />
           <Stack.Screen name="ClientRegister" component={ClientRegisterScreen} />
           <Stack.Screen name="ClientDashboard" component={ClientDashboardScreen} />
-          <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} options={{ title: 'Recuperar Password' }} />
+          <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} options={{ title: 'Recuperar Palavra-passe' }} />
           <Stack.Screen name="Dashboard" component={DashboardScreen} />
           <Stack.Screen name="Routes" component={RoutesScreen} options={{ title: 'Trajetos' }} />
           <Stack.Screen name="Stats" component={StatsScreen} options={{ title: t('statsTitle') }} />

--- a/mobile/i18n.js
+++ b/mobile/i18n.js
@@ -38,11 +38,30 @@ const translations = {
     manageAccount: 'Definições',
     aboutHelp: 'Sobre/Ajuda',
   },
+  'pt-PT': {
+    statsTitle: 'Estatísticas',
+    noRoutes: 'Nenhum trajeto registado',
+    favorites: 'Favoritos',
+    addFavorite: 'Adicionar aos favoritos',
+    removeFavorite: 'Remover favorito',
+    paidWeeksTitle: 'Semanas Pagas',
+    languageTitle: 'Idioma',
+    english: 'Inglês',
+    portuguese: 'Português',
+    accountSettingsTitle: 'Definições de Conta',
+    notificationsEnabled: 'Ativar notificações',
+    notificationRadius: 'Raio para notificações (m)',
+    clearFavorites: 'Limpar favoritos',
+    proximityMenu: 'Notificações de proximidade',
+    manageAccount: 'Definições',
+    aboutHelp: 'Sobre/Ajuda',
+  },
 };
 
 const i18n = new I18n(translations);
 i18n.enableFallback = true;
-i18n.locale = Localization.locale;
+// Forçar português de Portugal por omissão
+i18n.locale = Localization.locale.startsWith('pt') ? 'pt-PT' : 'en';
 
 export default function t(key) {
   return i18n.t(key);

--- a/mobile/screens/ClientLoginScreen.js
+++ b/mobile/screens/ClientLoginScreen.js
@@ -80,7 +80,7 @@ export default function ClientLoginScreen({ navigation }) {
       <TextInput
         mode="outlined"
         style={styles.input}
-        label="Password"
+        label="Palavra-passe"
         secureTextEntry
         value={password}
         onChangeText={(t) => {

--- a/mobile/screens/ClientRegisterScreen.js
+++ b/mobile/screens/ClientRegisterScreen.js
@@ -37,7 +37,7 @@ export default function ClientRegisterScreen({ navigation }) {
       return;
     }
     if (password.length < 8 || password.toLowerCase() === password) {
-      setError('Password deve ter 8 caracteres e uma letra maiúscula');
+      setError('Palavra-passe deve ter 8 caracteres e uma letra maiúscula');
       return;
     }
     setLoading(true);
@@ -98,7 +98,7 @@ export default function ClientRegisterScreen({ navigation }) {
       <TextInput
         mode="outlined"
         style={styles.input}
-        label="Password"
+        label="Palavra-passe"
         secureTextEntry
         value={password}
         onChangeText={(t) => {

--- a/mobile/screens/DashboardScreen.js
+++ b/mobile/screens/DashboardScreen.js
@@ -155,7 +155,7 @@ if (share) {
   const updateProfile = async () => {
     if (!vendor) return;
     if (changingPassword && (!password || !oldPassword)) {
-      setError('Preencha as passwords');
+      setError('Preencha as palavras-passe');
       return;
     }
     try {
@@ -303,7 +303,7 @@ if (share) {
                 <TextInput
                   mode="outlined"
                   style={styles.input}
-                  label="Password atual"
+                  label="Palavra-passe atual"
                   secureTextEntry
                   value={oldPassword}
                   onChangeText={setOldPassword}
@@ -311,7 +311,7 @@ if (share) {
                 <TextInput
                   mode="outlined"
                   style={styles.input}
-                  label="Nova password"
+                  label="Nova palavra-passe"
                   secureTextEntry
                   value={password}
                   onChangeText={setPassword}
@@ -322,12 +322,12 @@ if (share) {
                 <TextInput
                   mode="outlined"
                   style={[styles.input, styles.inputDisabled]}
-                  label="Password"
+                  label="Palavra-passe"
                   value="********"
                   editable={false}
                 />
                 <Button mode="outlined" onPress={() => setChangingPassword(true)}>
-                  Alterar password
+                  Alterar palavra-passe
                 </Button>
               </>
             )}
@@ -464,7 +464,7 @@ if (share) {
         </View>
 
         <View style={[styles.fullButton, styles.logoutButton]}>
-          <Button mode="outlined" onPress={logout}>Logout</Button>
+          <Button mode="outlined" onPress={logout}>Sair</Button>
         </View>
       </ScrollView>
 

--- a/mobile/screens/ForgotPasswordScreen.js
+++ b/mobile/screens/ForgotPasswordScreen.js
@@ -1,4 +1,4 @@
-// Tela de recuperacao de password
+// Tela de recuperação de palavra-passe
 import React, { useState } from 'react';
 import { View, StyleSheet, Alert } from 'react-native';
 import { TextInput, Button, Text, ActivityIndicator } from 'react-native-paper';
@@ -17,7 +17,7 @@ export default function ForgotPasswordScreen({ navigation }) {
     setError(null);
     try {
       await axios.post(`${BASE_URL}/password-reset-request`, { email });
-      Alert.alert('Pedido enviado', 'Verifique o seu e-mail para definir nova password.');
+      Alert.alert('Pedido enviado', 'Verifique o seu e-mail para definir nova palavra-passe.');
       navigation.goBack();
     } catch (err) {
       console.error(err);

--- a/mobile/screens/LoginScreen.js
+++ b/mobile/screens/LoginScreen.js
@@ -91,7 +91,7 @@ export default function LoginScreen({ navigation }) {
       <TextInput
         mode="outlined"
         style={styles.input}
-        label="Password"
+        label="Palavra-passe"
         secureTextEntry
         value={password}
         onChangeText={(text) => {
@@ -116,7 +116,7 @@ export default function LoginScreen({ navigation }) {
         mode="text"
         onPress={() => navigation.navigate('ForgotPassword')}
       >
-        Esqueci a minha password
+        Esqueci-me da palavra-passe
       </Button>
     </View>
   );

--- a/mobile/screens/ManageAccountScreen.js
+++ b/mobile/screens/ManageAccountScreen.js
@@ -19,14 +19,14 @@ export default function ManageAccountScreen() {
       <Text style={styles.title}>Definições</Text>
       <TextInput
         mode="outlined"
-        label="Nova password"
+        label="Nova palavra-passe"
         secureTextEntry
         value={password}
         onChangeText={setPassword}
         style={styles.input}
       />
       <Button mode="contained" onPress={changePassword} style={styles.button}>
-        Alterar Password
+        Alterar Palavra-passe
       </Button>
       <Button mode="contained" onPress={deleteAccount} style={styles.button}>
         Apagar Conta

--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -292,7 +292,7 @@ export default function MapScreen({ navigation }) {
           navigation.navigate(vendorUser ? "Dashboard" : "VendorLogin")
         }
         accessibilityRole="button"
-        accessibilityLabel="Login Vendedor"
+        accessibilityLabel="Iniciar sessão de Vendedor"
         accessible
       >
         <MaterialCommunityIcons
@@ -428,7 +428,7 @@ export default function MapScreen({ navigation }) {
               style={styles.button}
               onPress={() => navigation.navigate("ClientLogin")}
             >
-              Login Cliente
+              Iniciar sessão Cliente
             </Button>
 
             <Button

--- a/mobile/screens/RegisterScreen.js
+++ b/mobile/screens/RegisterScreen.js
@@ -40,7 +40,7 @@ export default function RegisterScreen({ navigation }) {
       return;
     }
     if (password.length < 8 || password.toLowerCase() === password) {
-      setError('Password deve ter 8 caracteres e uma letra maiúscula');
+      setError('Palavra-passe deve ter 8 caracteres e uma letra maiúscula');
       return;
     }
 
@@ -119,7 +119,7 @@ export default function RegisterScreen({ navigation }) {
       <TextInput
         mode="outlined"
         style={styles.input}
-        label="Password"
+        label="Palavra-passe"
         secureTextEntry
         value={password}
         onChangeText={(text) => {


### PR DESCRIPTION
## Summary
- switch interface strings to European Portuguese
- force Portuguese locale

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685b3474b8c0832e9c39cc849412fd84