### PR TITLE
Update client dashboard UI

### DIFF
--- a/mobile/screens/ClientDashboardScreen.js
+++ b/mobile/screens/ClientDashboardScreen.js
@@ -1,6 +1,6 @@
 // Dashboard simples para o cliente listar os vendedores favoritos
 import React, { useEffect, useState } from 'react';
-import { View, StyleSheet, Image, FlatList, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, Image, FlatList, TouchableOpacity, ScrollView } from 'react-native';
 import { Text, Button } from 'react-native-paper';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
@@ -10,8 +10,23 @@ import { theme } from '../theme';
 import t from '../i18n';
 
 export default function ClientDashboardScreen({ navigation }) {
+  const [client, setClient] = useState(null);
   const [favorites, setFavorites] = useState([]);
   const [menuOpen, setMenuOpen] = useState(false);
+
+  const loadClient = async () => {
+    try {
+      const stored = await AsyncStorage.getItem('client');
+      if (stored) {
+        setClient(JSON.parse(stored));
+      } else {
+        setClient(null);
+      }
+    } catch (e) {
+      console.log('Erro ao carregar cliente:', e);
+      setClient(null);
+    }
+  };
 
   // # Função para carregar os favoritos
   const loadFavorites = async () => {
@@ -42,54 +57,90 @@ export default function ClientDashboardScreen({ navigation }) {
     navigation.replace('ClientLogin');
   };
 
-  // # Carregar favoritos ao abrir e quando voltar ao ecrã
+  // # Carregar dados ao abrir e quando voltar ao ecrã
   useEffect(() => {
     loadFavorites();
-    const unsubscribe = navigation.addListener('focus', loadFavorites);
+    loadClient();
+    const unsubscribe = navigation.addListener('focus', () => {
+      loadFavorites();
+      loadClient();
+    });
     return unsubscribe;
   }, [navigation]);
 
   // # Return do componente
   return (
-    // (em português) Este componente mostra os favoritos e um menu lateral para definições e ações
     <View style={{ flex: 1 }}>
-      <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.container}>
+        <TouchableOpacity
+          style={styles.mapButton}
+          onPress={() => navigation.navigate('Map')}
+        >
+          <Text style={styles.mapIcon}>🗺️</Text>
+        </TouchableOpacity>
+
         <TouchableOpacity
           style={styles.menuButton}
           onPress={() => setMenuOpen(!menuOpen)}
         >
           <Text style={styles.menuIcon}>☰</Text>
         </TouchableOpacity>
-        <Text style={styles.title}>Favoritos</Text>
-        <FlatList
-          data={favorites}
-          keyExtractor={(item) => item.id.toString()}
-          renderItem={({ item }) => {
-            const photoUri = item.profile_photo
-              ? `${BASE_URL.replace(/\/$/, '')}/${item.profile_photo}`
-              : null;
-            return (
-              <TouchableOpacity
-                style={styles.vendor}
-                onPress={() => navigation.navigate('VendorDetail', { vendor: item })}
-              >
-                {photoUri && (
-                  <Image
-                    source={{ uri: photoUri }}
-                    style={[
-                      styles.image,
-                      item.subscription_active
-                        ? styles.activePhoto
-                        : styles.inactivePhoto,
-                    ]}
-                  />
-                )}
-                <Text>{item.name}</Text>
-              </TouchableOpacity>
-            );
-          }}
-        />
-      </View>
+
+        <Text style={styles.title}>Meu Perfil</Text>
+
+        {client?.profile_photo && (
+          <Image
+            source={{ uri: `${BASE_URL.replace(/\/$/, '')}/${client.profile_photo}` }}
+            style={styles.imagePreview}
+          />
+        )}
+        {client && (
+          <>
+            <Text style={styles.infoText}>
+              <Text style={styles.label}>Nome:</Text> {client.name}
+            </Text>
+            <Text style={styles.infoText}>
+              <Text style={styles.label}>Email:</Text> {client.email}
+            </Text>
+          </>
+        )}
+
+        <View style={styles.favoriteSection}>
+          <Text style={styles.sectionTitle}>Vendedores Favoritos</Text>
+          <FlatList
+            data={favorites}
+            keyExtractor={(item) => item.id.toString()}
+            renderItem={({ item }) => {
+              const photoUri = item.profile_photo
+                ? `${BASE_URL.replace(/\/$/, '')}/${item.profile_photo}`
+                : null;
+              return (
+                <TouchableOpacity
+                  style={styles.vendor}
+                  onPress={() => navigation.navigate('VendorDetail', { vendor: item })}
+                >
+                  {photoUri && (
+                    <Image
+                      source={{ uri: photoUri }}
+                      style={[
+                        styles.image,
+                        item.subscription_active
+                          ? styles.activePhoto
+                          : styles.inactivePhoto,
+                      ]}
+                    />
+                  )}
+                  <Text>{item.name}</Text>
+                </TouchableOpacity>
+              );
+            }}
+          />
+        </View>
+
+        <View style={[styles.fullButton, styles.logoutButton]}>
+          <Button mode="outlined" onPress={logout}>Sair</Button>
+        </View>
+      </ScrollView>
 
       {menuOpen && (
         <View style={styles.menu}>
@@ -115,8 +166,17 @@ export default function ClientDashboardScreen({ navigation }) {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 16, backgroundColor: theme.colors.background },
-  title: { fontSize: 18, marginBottom: 12, textAlign: 'center' },
+  container: {
+    flexGrow: 1,
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    padding: 16,
+    backgroundColor: theme.colors.background,
+  },
+  title: { fontSize: 20, fontWeight: 'bold', marginBottom: 16 },
+  infoText: { marginBottom: 8, width: '100%' },
+  label: { fontWeight: 'bold' },
+  imagePreview: { width: 120, height: 120, marginVertical: 12, borderRadius: 60 },
   vendor: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -129,6 +189,12 @@ const styles = StyleSheet.create({
   inactivePhoto: { borderWidth: 2, borderColor: 'red' },
   button: { marginTop: 12 },
   logout: { marginTop: 20 },
+  favoriteSection: { width: '100%', marginTop: 16 },
+  sectionTitle: { fontWeight: 'bold', marginBottom: 4 },
+  fullButton: { width: '100%', marginBottom: 12 },
+  logoutButton: { marginTop: 'auto' },
+  mapButton: { position: 'absolute', top: 16, right: 16 },
+  mapIcon: { fontSize: 50 },
   menuButton: { position: 'absolute', top: 16, left: 16 },
   menuIcon: { fontSize: 40 },
   menu: {


### PR DESCRIPTION
## Summary
- revamp beach client dashboard to resemble the vendor profile
- display profile photo, name and email
- show favorite vendors list with active/inactive highlight
- add map button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685bc3c407c0832ead635e31f5fb6c31