### PR TITLE
Add login prompt for adding favorites

### DIFF
--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   FlatList,
   Image,
+  Alert,
 } from "react-native";
 import { Button, Text, TextInput, ActivityIndicator } from "react-native-paper";
 import { Picker } from "@react-native-picker/picker";
@@ -389,6 +390,13 @@ export default function MapScreen({ navigation }) {
                         fav ? t("removeFavorite") : t("addFavorite")
                       }
                       onPress={async () => {
+                        if (!clientUser) {
+                          Alert.alert(
+                            'Inicie sessão',
+                            'É necessário iniciar sessão para adicionar favoritos.'
+                          );
+                          return;
+                        }
                         if (fav) {
                           await removeFavorite(item.id);
                         } else {

--- a/mobile/screens/VendorDetailScreen.js
+++ b/mobile/screens/VendorDetailScreen.js
@@ -89,6 +89,14 @@ const submitReview = async () => {
           accessibilityRole="button"
           accessibilityLabel={favorite ? t('removeFavorite') : t('addFavorite')}
           onPress={async () => {
+            const token = await AsyncStorage.getItem('clientToken');
+            if (!token) {
+              Alert.alert(
+                'Inicie sessão',
+                'É necessário iniciar sessão para adicionar favoritos.'
+              );
+              return;
+            }
             if (favorite) {
               await removeFavorite(vendor.id);
             } else {


### PR DESCRIPTION
## Summary
- require logged-in client to save vendor favorites

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685c6cba6f1c832ea844557612aec12f