### PR TITLE
Add Portuguese comments throughout code

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,1 +1,1 @@
-
+# Pacote do backend da aplicação Sunny Sales

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,1 +1,1 @@
-
+# Pacote principal com modelos e rotas FastAPI

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,3 +1,4 @@
+# Configura a ligação à base de dados e fornece sessão SQLAlchemy
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker

--- a/mobile/favoritesService.js
+++ b/mobile/favoritesService.js
@@ -1,3 +1,4 @@
+// Serviço utilitário para guardar vendedores favoritos em armazenamento local
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const KEY = 'favorites';

--- a/mobile/i18n.js
+++ b/mobile/i18n.js
@@ -1,3 +1,4 @@
+// Configuração e dicionários de tradução para a app
 import { I18n } from 'i18n-js';
 import * as Localization from 'expo-localization';
 

--- a/mobile/screens/AboutScreen.js
+++ b/mobile/screens/AboutScreen.js
@@ -1,3 +1,4 @@
+// Ecrã que apresenta informações de ajuda e navegação para Termos ou Suporte
 import React from 'react';
 import { View, StyleSheet, Linking } from 'react-native';
 import { Button, Text } from 'react-native-paper';
@@ -7,6 +8,7 @@ export default function AboutScreen({ navigation }) {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Sobre e Ajuda</Text>
+      {/* Botão para abrir ecrã de Termos */}
       <Button
         mode="outlined"
         onPress={() => navigation.navigate('Terms')}
@@ -14,6 +16,7 @@ export default function AboutScreen({ navigation }) {
       >
         <Text>Termos e Condições</Text>
       </Button>
+      {/* Botão para contactar a equipa de suporte */}
       <Button
         mode="outlined"
         onPress={() => Linking.openURL('mailto:suporte@sunnysales.com')}

--- a/mobile/screens/AccountSettingsScreen.js
+++ b/mobile/screens/AccountSettingsScreen.js
@@ -1,3 +1,4 @@
+// Ecrã de configurações de conta onde o utilizador ajusta notificações
 import React, { useEffect, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Switch, Text } from 'react-native-paper';
@@ -38,11 +39,13 @@ export default function AccountSettingsScreen() {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>{t('accountSettingsTitle')}</Text>
+      {/* Interruptor para ativar ou desativar notificações */}
       <View style={styles.row}>
         <Text>{t('notificationsEnabled')}</Text>
         <Switch value={enabled} onValueChange={toggleNotifications} />
       </View>
       <Text>{t('notificationRadius')}</Text>
+      {/* Menu suspenso para escolher o raio de alertas */}
       <Picker
         selectedValue={parseInt(radius, 10)}
         onValueChange={changeRadius}

--- a/mobile/screens/InvoicesScreen.js
+++ b/mobile/screens/InvoicesScreen.js
@@ -1,3 +1,4 @@
+// Ecrã de histórico de faturas (reutiliza PaidWeeksScreen)
 import PaidWeeksScreen from './PaidWeeksScreen';
 
 export default PaidWeeksScreen;

--- a/mobile/screens/ManageAccountScreen.js
+++ b/mobile/screens/ManageAccountScreen.js
@@ -1,3 +1,4 @@
+// Ecrã para gestão de conta com mudança e remoção de utilizador
 import React from 'react';
 import { View, StyleSheet, Alert } from 'react-native';
 import { Button, Text, TextInput } from 'react-native-paper';
@@ -25,9 +26,11 @@ export default function ManageAccountScreen() {
         onChangeText={setPassword}
         style={styles.input}
       />
+      {/* Botão para alterar a palavra-passe */}
       <Button mode="contained" onPress={changePassword} style={styles.button}>
         <Text>Alterar Palavra-passe</Text>
       </Button>
+      {/* Botão para apagar a conta */}
       <Button mode="contained" onPress={deleteAccount} style={styles.button}>
         <Text>Apagar Conta</Text>
       </Button>

--- a/mobile/screens/PaidWeeksScreen.js
+++ b/mobile/screens/PaidWeeksScreen.js
@@ -1,3 +1,4 @@
+// Ecrã que lista semanas pagas e respetivos recibos
 import React, { useState, useEffect } from 'react';
 import { View, FlatList, StyleSheet, Linking } from 'react-native';
 import { Text, List } from 'react-native-paper';
@@ -35,6 +36,7 @@ export default function PaidWeeksScreen({ navigation }) {
     const start = new Date(item.start_date).toLocaleDateString();
     const end = new Date(item.end_date).toLocaleDateString();
     return (
+      {/* Item que abre o recibo da semana paga */}
       <List.Item
         style={styles.item}
         title={`${start} - ${end}`}

--- a/mobile/screens/StatsScreen.js
+++ b/mobile/screens/StatsScreen.js
@@ -1,3 +1,4 @@
+// Ecrã de estatísticas de distâncias percorridas
 import React, { useState, useEffect } from 'react';
 import { View, StyleSheet, Dimensions, ScrollView } from 'react-native';
 import { Text } from 'react-native-paper';
@@ -45,6 +46,7 @@ export default function StatsScreen({ navigation }) {
       {data.length > 0 ? (
         <>
           <Text style={styles.title}>{t('statsTitle')}</Text>
+          {/* Gráfico de barras com as distâncias por dia */}
           <BarChart
             data={{
               labels: labels,

--- a/mobile/settingsService.js
+++ b/mobile/settingsService.js
@@ -1,3 +1,4 @@
+// Guardar e ler definições de notificações no armazenamento local
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const ENABLED_KEY = 'notifications_enabled';


### PR DESCRIPTION
## Summary
- describe database module
- annotate service utilities and translation config
- add screen descriptions and annotate UI elements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685d8477aa28832ea132ca12d0d48242