### PR TITLE
Add back button across app screens

### DIFF
--- a/mobile/BackButton.js
+++ b/mobile/BackButton.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { IconButton } from 'react-native-paper';
+import { useNavigation } from '@react-navigation/native';
+import { theme } from './theme';
+
+export default function BackButton({ style }) {
+  const navigation = useNavigation();
+  if (!navigation.canGoBack()) return null;
+  return (
+    <IconButton
+      icon="arrow-left"
+      size={28}
+      onPress={navigation.goBack}
+      style={style}
+      accessibilityLabel="Voltar"
+      iconColor={theme.colors.primary}
+    />
+  );
+}
+

--- a/mobile/screens/AccountSettingsScreen.js
+++ b/mobile/screens/AccountSettingsScreen.js
@@ -11,6 +11,7 @@ import {
 } from '../settingsService';
 import { theme } from '../theme';
 import t from '../i18n';
+import BackButton from '../BackButton';
 
 export default function AccountSettingsScreen() {
   const [enabled, setEnabled] = useState(true);
@@ -38,6 +39,7 @@ export default function AccountSettingsScreen() {
 
   return (
     <View style={styles.container}>
+      <BackButton style={styles.back} />
       <Text style={styles.title}>{t('accountSettingsTitle')}</Text>
       {/* Interruptor para ativar ou desativar notificações */}
       <View style={styles.row}>
@@ -64,4 +66,5 @@ const styles = StyleSheet.create({
   title: { fontSize: 20, marginBottom: 16 },
   row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 },
   picker: { marginBottom: 16 },
+  back: { position: 'absolute', top: 16, left: 16 },
 });

--- a/mobile/screens/ClientLoginScreen.js
+++ b/mobile/screens/ClientLoginScreen.js
@@ -11,6 +11,7 @@ import axios from 'axios';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { BASE_URL } from '../config';
 import { theme } from '../theme';
+import BackButton from '../BackButton';
 
 export default function ClientLoginScreen({ navigation }) {
   const [email, setEmail] = useState('');
@@ -65,6 +66,7 @@ export default function ClientLoginScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
+      <BackButton style={styles.back} />
       {error && <Text style={styles.error}>{error}</Text>}
       <TextInput
         mode="outlined"
@@ -107,4 +109,5 @@ const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 16, backgroundColor: theme.colors.background },
   input: { marginBottom: 12 },
   error: { color: 'red', marginBottom: 12, textAlign: 'center' },
+  back: { position: 'absolute', top: 16, left: 16 },
 });

--- a/mobile/screens/ClientRegisterScreen.js
+++ b/mobile/screens/ClientRegisterScreen.js
@@ -11,6 +11,7 @@ import * as ImagePicker from 'expo-image-picker';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import { theme } from '../theme';
+import BackButton from '../BackButton';
 
 export default function ClientRegisterScreen({ navigation }) {
   const [name, setName] = useState('');
@@ -73,6 +74,7 @@ export default function ClientRegisterScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
+      <BackButton style={styles.back} />
       {error && <Text style={styles.error}>{error}</Text>}
       <TextInput
         mode="outlined"
@@ -135,4 +137,5 @@ const styles = StyleSheet.create({
     borderRadius: 50,
     alignSelf: 'center',
   },
+  back: { position: 'absolute', top: 16, left: 16 },
 });

--- a/mobile/screens/LoginScreen.js
+++ b/mobile/screens/LoginScreen.js
@@ -11,6 +11,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import { theme } from '../theme';
+import BackButton from '../BackButton';
 
 export default function LoginScreen({ navigation }) {
   const [email, setEmail] = useState('');
@@ -73,6 +74,7 @@ export default function LoginScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
+      <BackButton style={styles.back} />
       {error && <Text style={styles.error}>{error}</Text>}
       <Text style={styles.notice}>Esta página destina-se apenas a vendedores.</Text>
 
@@ -128,4 +130,5 @@ const styles = StyleSheet.create({
   input: { marginBottom: 12 },
   error: { color: 'red', marginBottom: 12, textAlign: 'center' },
   notice: { marginBottom: 12, textAlign: 'center' },
+  back: { position: 'absolute', top: 16, left: 16 },
 });

--- a/mobile/screens/ManageAccountScreen.js
+++ b/mobile/screens/ManageAccountScreen.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { View, StyleSheet, Alert } from 'react-native';
 import { Button, Text, TextInput } from 'react-native-paper';
 import { theme } from '../theme';
+import BackButton from '../BackButton';
 
 export default function ManageAccountScreen() {
   const [password, setPassword] = React.useState('');
@@ -17,6 +18,7 @@ export default function ManageAccountScreen() {
 
   return (
     <View style={styles.container}>
+      <BackButton style={styles.back} />
       <Text style={styles.title}>Definições</Text>
       <TextInput
         mode="outlined"
@@ -43,4 +45,5 @@ const styles = StyleSheet.create({
   title: { fontSize: 20, marginBottom: 16, textAlign: 'center' },
   input: { marginBottom: 16 },
   button: { marginBottom: 12 },
+  back: { position: 'absolute', top: 16, left: 16 },
 });

--- a/mobile/screens/PaidWeeksScreen.js
+++ b/mobile/screens/PaidWeeksScreen.js
@@ -6,6 +6,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import { theme } from '../theme';
+import BackButton from '../BackButton';
 
 export default function PaidWeeksScreen({ navigation }) {
   const [weeks, setWeeks] = useState([]);
@@ -47,6 +48,7 @@ const renderItem = ({ item }) => {
 
   return (
     <View style={styles.container}>
+      <BackButton style={styles.back} />
       <FlatList data={weeks} keyExtractor={(w) => w.id.toString()} renderItem={renderItem} />
     </View>
   );
@@ -59,4 +61,5 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: '#ccc',
   },
+  back: { position: 'absolute', top: 16, left: 16 },
 });

--- a/mobile/screens/RouteDetailScreen.js
+++ b/mobile/screens/RouteDetailScreen.js
@@ -4,6 +4,7 @@ import { View, StyleSheet } from 'react-native';
 import { Text } from 'react-native-paper';
 import { theme } from '../theme';
 import LeafletMap from '../LeafletMap';
+import BackButton from '../BackButton';
 
 export default function RouteDetailScreen({ route }) {
   const r = route.params.route;
@@ -16,6 +17,7 @@ export default function RouteDetailScreen({ route }) {
     : { latitude: 0, longitude: 0 };
   return (
     <View style={styles.container}>
+      <BackButton style={styles.back} />
       <LeafletMap initialPosition={initial} polyline={polyline} />
       <View style={styles.info}>
         <Text>Início: {start.toLocaleString()}</Text>
@@ -30,4 +32,5 @@ export default function RouteDetailScreen({ route }) {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
   info: { padding: 16 },
+  back: { position: 'absolute', top: 16, left: 16, zIndex: 1 },
 });

--- a/mobile/screens/RoutesScreen.js
+++ b/mobile/screens/RoutesScreen.js
@@ -6,6 +6,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import { theme } from '../theme';
+import BackButton from '../BackButton';
 
 export default function RoutesScreen({ navigation }) {
   const [routes, setRoutes] = useState([]);
@@ -49,6 +50,7 @@ export default function RoutesScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
+      <BackButton style={styles.back} />
       <FlatList data={routes} keyExtractor={(r) => r.id.toString()} renderItem={renderItem} />
     </View>
   );
@@ -61,4 +63,5 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: '#ccc',
   },
+  back: { position: 'absolute', top: 16, left: 16 },
 });

--- a/mobile/screens/StatsScreen.js
+++ b/mobile/screens/StatsScreen.js
@@ -8,6 +8,7 @@ import { BarChart } from 'react-native-chart-kit';
 import { BASE_URL } from '../config';
 import { theme } from '../theme';
 import t from '../i18n';
+import BackButton from '../BackButton';
 
 export default function StatsScreen({ navigation }) {
   const [data, setData] = useState([]);
@@ -43,6 +44,7 @@ export default function StatsScreen({ navigation }) {
 
   return (
     <ScrollView contentContainerStyle={styles.container} accessible accessibilityLabel={t('statsTitle')}>
+      <BackButton style={styles.back} />
       {data.length > 0 ? (
         <>
           <Text style={styles.title}>{t('statsTitle')}</Text>
@@ -78,4 +80,5 @@ export default function StatsScreen({ navigation }) {
 const styles = StyleSheet.create({
   container: { flexGrow: 1, padding: 16, backgroundColor: theme.colors.background, alignItems: 'center' },
   title: { fontSize: 20, fontWeight: 'bold', marginBottom: 10 },
+  back: { position: 'absolute', top: 16, left: 16 },
 });

--- a/mobile/screens/TermsScreen.js
+++ b/mobile/screens/TermsScreen.js
@@ -4,10 +4,12 @@ import React from 'react';
 import { View, StyleSheet, ScrollView } from 'react-native';
 import { Text } from 'react-native-paper';
 import { theme } from '../theme';
+import BackButton from '../BackButton';
 
 export default function TermsScreen() {
   return (
     <ScrollView contentContainerStyle={styles.container}>
+      <BackButton style={styles.back} />
       <Text style={styles.title}>Termos e Condições</Text>
 
       <Text style={styles.sectionTitle}>1. Aceitação dos Termos</Text>
@@ -82,5 +84,6 @@ const styles = StyleSheet.create({
     marginBottom: 8,
     textAlign: 'justify',
   },
+  back: { position: 'absolute', top: 16, left: 16 },
 });
 


### PR DESCRIPTION
## Summary
- create reusable `BackButton` component
- show the BackButton on login/registration pages
- add back navigation to vendor and client settings screens
- add back button to stats, routes and other menu pages

## Testing
- `pytest` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685daff29a70832e99d067ea7256b639