### PR TITLE
Add React web skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .env.*
 !.env.example
 profile_photos/
+web/node_modules/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Aplicação composta por backend em **FastAPI** e app móvel em **React Native**
 ```
 backend/    Código do servidor FastAPI
 mobile/     Aplicação React Native (Expo)
+web/        Site React para navegadores
 scripts/    Utilidades auxiliares
 ```
 
@@ -30,6 +31,11 @@ scripts/    Utilidades auxiliares
    ```bash
    npm install
    npx expo start
+   ```
+6. Para o site Web entre em `web`, instale dependências e execute:
+   ```bash
+   npm install
+   npm start
    ```
 
 ## Novidades

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+build/
+.env
+.DS_Store

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,11 @@
+# Web Frontend
+
+Site em React que consome a API do backend FastAPI. Para iniciar em modo de desenvolvimento:
+
+```bash
+cd web
+npm install
+npm start
+```
+
+Defina a variável `REACT_APP_BASE_URL` para apontar para o backend se necessário.

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "ss-web",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "axios": "^1.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.14.0",
+    "react-scripts": "5.0.1",
+    "leaflet": "^1.9.4"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="pt">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sunny Sales Web</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -1,0 +1,24 @@
+import { Routes, Route } from 'react-router-dom';
+import LoginPage from './pages/LoginPage';
+import VendorDashboard from './pages/VendorDashboard';
+import PublicMapPage from './pages/PublicMapPage';
+import PrivateRoute from './components/PrivateRoute';
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route
+        path="/vendor"
+        element={
+          <PrivateRoute>
+            <VendorDashboard />
+          </PrivateRoute>
+        }
+      />
+      <Route path="*" element={<PublicMapPage />} />
+    </Routes>
+  );
+}
+
+export default App;

--- a/web/src/components/PrivateRoute.js
+++ b/web/src/components/PrivateRoute.js
@@ -1,0 +1,9 @@
+import { Navigate } from 'react-router-dom';
+
+// Componente simples para proteger rotas que requerem autenticação
+const PrivateRoute = ({ children }) => {
+  const token = localStorage.getItem('token');
+  return token ? children : <Navigate to="/login" replace />;
+};
+
+export default PrivateRoute;

--- a/web/src/config.js
+++ b/web/src/config.js
@@ -1,0 +1,2 @@
+// URL base para o backend
+export const BASE_URL = process.env.REACT_APP_BASE_URL || 'http://localhost:8000';

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+}

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+);

--- a/web/src/pages/LoginPage.js
+++ b/web/src/pages/LoginPage.js
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { login } from '../services/api';
+import styles from './LoginPage.module.css';
+
+function LoginPage() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const data = await login(email, password);
+      localStorage.setItem('token', data.access_token);
+      navigate('/vendor');
+    } catch (err) {
+      setError('Credenciais inválidas');
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <h1>Login do Vendedor</h1>
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+        />
+        <button type="submit">Entrar</button>
+        {error && <p className={styles.error}>{error}</p>}
+      </form>
+    </div>
+  );
+}
+
+export default LoginPage;

--- a/web/src/pages/LoginPage.module.css
+++ b/web/src/pages/LoginPage.module.css
@@ -1,0 +1,14 @@
+.container {
+  max-width: 400px;
+  margin: 2rem auto;
+  text-align: center;
+}
+.form input {
+  display: block;
+  width: 100%;
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+}
+.error {
+  color: red;
+}

--- a/web/src/pages/PublicMapPage.js
+++ b/web/src/pages/PublicMapPage.js
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import { fetchActiveVendors } from '../services/api';
+import 'leaflet/dist/leaflet.css';
+import styles from './PublicMapPage.module.css';
+
+function PublicMapPage() {
+  const [vendors, setVendors] = useState([]);
+
+  useEffect(() => {
+    fetchActiveVendors().then(setVendors);
+  }, []);
+
+  const center = vendors.length
+    ? [vendors[0].current_lat, vendors[0].current_lng]
+    : [38.716, -9.139];
+
+  return (
+    <div className={styles.map}>
+      <MapContainer center={center} zoom={13} style={{ height: '100vh' }}>
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        {vendors.map(
+          (v) =>
+            v.current_lat && (
+              <Marker key={v.id} position={[v.current_lat, v.current_lng]}>
+                <Popup>
+                  <strong>{v.name}</strong>
+                  <br />
+                  {v.product}
+                </Popup>
+              </Marker>
+            )
+        )}
+      </MapContainer>
+    </div>
+  );
+}
+
+export default PublicMapPage;

--- a/web/src/pages/PublicMapPage.module.css
+++ b/web/src/pages/PublicMapPage.module.css
@@ -1,0 +1,4 @@
+.map {
+  width: 100%;
+  height: 100vh;
+}

--- a/web/src/pages/VendorDashboard.js
+++ b/web/src/pages/VendorDashboard.js
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { fetchVendorProfile, updateVendorLocation } from '../services/api';
+import styles from './VendorDashboard.module.css';
+
+function VendorDashboard() {
+  const navigate = useNavigate();
+  const [vendor, setVendor] = useState(null);
+  const token = localStorage.getItem('token');
+
+  useEffect(() => {
+    if (!token) return;
+    fetchVendorProfile(token).then(setVendor);
+  }, [token]);
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    navigate('/login');
+  };
+
+  const shareLocation = () => {
+    if (!navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition((pos) => {
+      updateVendorLocation(token, {
+        lat: pos.coords.latitude,
+        lng: pos.coords.longitude,
+      });
+    });
+  };
+
+  if (!vendor) return <p>Carregando...</p>;
+
+  return (
+    <div className={styles.container}>
+      <h1>Painel do Vendedor</h1>
+      <p>Nome: {vendor.name}</p>
+      <p>Produto: {vendor.product}</p>
+      <p>
+        Localização: {vendor.current_lat}, {vendor.current_lng}
+      </p>
+      <button onClick={shareLocation}>Partilhar localização</button>
+      <button onClick={logout}>Sair</button>
+    </div>
+  );
+}
+
+export default VendorDashboard;

--- a/web/src/pages/VendorDashboard.module.css
+++ b/web/src/pages/VendorDashboard.module.css
@@ -1,0 +1,4 @@
+.container {
+  max-width: 600px;
+  margin: 2rem auto;
+}

--- a/web/src/services/api.js
+++ b/web/src/services/api.js
@@ -1,0 +1,28 @@
+import axios from 'axios';
+import { BASE_URL } from '../config';
+
+const api = axios.create({
+  baseURL: BASE_URL,
+});
+
+export const login = (email, password) =>
+  api.post('/token', { email, password }).then((r) => r.data);
+
+export const fetchVendorProfile = (token) =>
+  api
+    .get('/vendors/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    .then((r) => r.data);
+
+export const updateVendorLocation = (token, coords) =>
+  api
+    .put('/vendors/me/location', coords, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    .then((r) => r.data);
+
+export const fetchActiveVendors = () =>
+  api.get('/vendors').then((r) => r.data);
+
+export default api;


### PR DESCRIPTION
## Summary
- create `web/` folder with initial React app using create-react-app structure
- add example pages, components, and API service
- document the new web app in README
- ignore `web/node_modules` in `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ec5d40068832eb1d0354671b57cb5