### PR TITLE
Implement basic i18n in React site

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -3,21 +3,25 @@ import LoginPage from './pages/LoginPage';
 import VendorDashboard from './pages/VendorDashboard';
 import PublicMapPage from './pages/PublicMapPage';
 import PrivateRoute from './components/PrivateRoute';
+import LanguageSelector from './components/LanguageSelector';
 
 function App() {
   return (
-    <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route
-        path="/vendor"
-        element={
-          <PrivateRoute>
-            <VendorDashboard />
-          </PrivateRoute>
-        }
-      />
-      <Route path="*" element={<PublicMapPage />} />
-    </Routes>
+    <>
+      <LanguageSelector />
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route
+          path="/vendor"
+          element={
+            <PrivateRoute>
+              <VendorDashboard />
+            </PrivateRoute>
+          }
+        />
+        <Route path="*" element={<PublicMapPage />} />
+      </Routes>
+    </>
   );
 }
 

--- a/web/src/components/LanguageSelector.js
+++ b/web/src/components/LanguageSelector.js
@@ -1,0 +1,13 @@
+import { useLang } from '../i18n';
+
+function LanguageSelector() {
+  const { lang, setLang } = useLang();
+  return (
+    <select value={lang} onChange={(e) => setLang(e.target.value)}>
+      <option value="pt">PT</option>
+      <option value="en">EN</option>
+    </select>
+  );
+}
+
+export default LanguageSelector;

--- a/web/src/i18n.js
+++ b/web/src/i18n.js
@@ -1,0 +1,49 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+
+const translations = {
+  en: {
+    loginTitle: 'Vendor Login',
+    emailPlaceholder: 'Email',
+    passwordPlaceholder: 'Password',
+    loginButton: 'Login',
+    invalidCredentials: 'Invalid credentials',
+    vendorPanel: 'Vendor Dashboard',
+    name: 'Name',
+    product: 'Product',
+    location: 'Location',
+    shareLocation: 'Share location',
+    logout: 'Logout',
+  },
+  pt: {
+    loginTitle: 'Login do Vendedor',
+    emailPlaceholder: 'Email',
+    passwordPlaceholder: 'Password',
+    loginButton: 'Entrar',
+    invalidCredentials: 'Credenciais inválidas',
+    vendorPanel: 'Painel do Vendedor',
+    name: 'Nome',
+    product: 'Produto',
+    location: 'Localização',
+    shareLocation: 'Partilhar localização',
+    logout: 'Sair',
+  },
+};
+
+const defaultLang = localStorage.getItem('lang') || (navigator.language.startsWith('pt') ? 'pt' : 'en');
+
+const I18nContext = createContext({ lang: defaultLang, setLang: () => {} });
+
+export const I18nProvider = ({ children }) => {
+  const [lang, setLang] = useState(defaultLang);
+  useEffect(() => {
+    localStorage.setItem('lang', lang);
+  }, [lang]);
+  return <I18nContext.Provider value={{ lang, setLang }}>{children}</I18nContext.Provider>;
+};
+
+export const useLang = () => useContext(I18nContext);
+
+export const useTranslation = () => {
+  const { lang } = useContext(I18nContext);
+  return (key) => translations[lang][key] || key;
+};

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -3,10 +3,13 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
+import { I18nProvider } from './i18n';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <BrowserRouter>
-    <App />
+    <I18nProvider>
+      <App />
+    </I18nProvider>
   </BrowserRouter>
 );

--- a/web/src/pages/LoginPage.js
+++ b/web/src/pages/LoginPage.js
@@ -2,9 +2,11 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { login } from '../services/api';
 import styles from './LoginPage.module.css';
+import { useTranslation } from '../i18n';
 
 function LoginPage() {
   const navigate = useNavigate();
+  const t = useTranslation();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -16,26 +18,26 @@ function LoginPage() {
       localStorage.setItem('token', data.access_token);
       navigate('/vendor');
     } catch (err) {
-      setError('Credenciais inválidas');
+      setError(t('invalidCredentials'));
     }
   };
 
   return (
     <div className={styles.container}>
-      <h1>Login do Vendedor</h1>
+      <h1>{t('loginTitle')}</h1>
       <form onSubmit={handleSubmit} className={styles.form}>
         <input
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          placeholder="Email"
+          placeholder={t('emailPlaceholder')}
         />
         <input
           type="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          placeholder="Password"
+          placeholder={t('passwordPlaceholder')}
         />
-        <button type="submit">Entrar</button>
+        <button type="submit">{t('loginButton')}</button>
         {error && <p className={styles.error}>{error}</p>}
       </form>
     </div>

--- a/web/src/pages/VendorDashboard.js
+++ b/web/src/pages/VendorDashboard.js
@@ -2,9 +2,11 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { fetchVendorProfile, updateVendorLocation } from '../services/api';
 import styles from './VendorDashboard.module.css';
+import { useTranslation } from '../i18n';
 
 function VendorDashboard() {
   const navigate = useNavigate();
+  const t = useTranslation();
   const [vendor, setVendor] = useState(null);
   const token = localStorage.getItem('token');
 
@@ -32,14 +34,18 @@ function VendorDashboard() {
 
   return (
     <div className={styles.container}>
-      <h1>Painel do Vendedor</h1>
-      <p>Nome: {vendor.name}</p>
-      <p>Produto: {vendor.product}</p>
+      <h1>{t('vendorPanel')}</h1>
       <p>
-        Localização: {vendor.current_lat}, {vendor.current_lng}
+        {t('name')}: {vendor.name}
       </p>
-      <button onClick={shareLocation}>Partilhar localização</button>
-      <button onClick={logout}>Sair</button>
+      <p>
+        {t('product')}: {vendor.product}
+      </p>
+      <p>
+        {t('location')}: {vendor.current_lat}, {vendor.current_lng}
+      </p>
+      <button onClick={shareLocation}>{t('shareLocation')}</button>
+      <button onClick={logout}>{t('logout')}</button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add simple translation context and dictionary
- allow changing language with a LanguageSelector component
- wrap app with I18nProvider
- update login and dashboard pages to use translation keys

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ec75df26c832e9a26a38272320585