### PR TITLE
Add basic pages for web version

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,9 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.0",
     "react-scripts": "5.0.1",
-    "leaflet": "^1.9.4"
+    "leaflet": "^1.9.4",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.4.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -1,6 +1,20 @@
 import { Routes, Route } from 'react-router-dom';
 import LoginPage from './pages/LoginPage';
+import RegisterPage from './pages/RegisterPage';
+import ForgotPasswordPage from './pages/ForgotPasswordPage';
+import ClientLoginPage from './pages/ClientLoginPage';
+import ClientRegisterPage from './pages/ClientRegisterPage';
 import VendorDashboard from './pages/VendorDashboard';
+import ClientDashboardPage from './pages/ClientDashboardPage';
+import AboutPage from './pages/AboutPage';
+import TermsPage from './pages/TermsPage';
+import RoutesPage from './pages/RoutesPage';
+import RouteDetailPage from './pages/RouteDetailPage';
+import StatsPage from './pages/StatsPage';
+import PaidWeeksPage from './pages/PaidWeeksPage';
+import ManageAccountPage from './pages/ManageAccountPage';
+import AccountSettingsPage from './pages/AccountSettingsPage';
+import VendorDetailPage from './pages/VendorDetailPage';
 import PublicMapPage from './pages/PublicMapPage';
 import PrivateRoute from './components/PrivateRoute';
 import LanguageSelector from './components/LanguageSelector';
@@ -11,6 +25,11 @@ function App() {
       <LanguageSelector />
       <Routes>
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/forgot" element={<ForgotPasswordPage />} />
+        <Route path="/client/login" element={<ClientLoginPage />} />
+        <Route path="/client/register" element={<ClientRegisterPage />} />
+        <Route path="/client" element={<ClientDashboardPage />} />
         <Route
           path="/vendor"
           element={
@@ -19,6 +38,15 @@ function App() {
             </PrivateRoute>
           }
         />
+        <Route path="/routes" element={<RoutesPage />} />
+        <Route path="/routes/:id" element={<RouteDetailPage />} />
+        <Route path="/stats" element={<StatsPage />} />
+        <Route path="/paid" element={<PaidWeeksPage />} />
+        <Route path="/manage" element={<ManageAccountPage />} />
+        <Route path="/settings" element={<AccountSettingsPage />} />
+        <Route path="/vendor/:id" element={<VendorDetailPage />} />
+        <Route path="/about" element={<AboutPage />} />
+        <Route path="/terms" element={<TermsPage />} />
         <Route path="*" element={<PublicMapPage />} />
       </Routes>
     </>

--- a/web/src/pages/AboutPage.js
+++ b/web/src/pages/AboutPage.js
@@ -1,0 +1,22 @@
+// Página com atalhos para os Termos e contacto com o suporte
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+function AboutPage() {
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Sobre e Ajuda</h1>
+      <p>
+        Esta área permite consultar os Termos e contactar a equipa de suporte.
+      </p>
+      <p>
+        <Link to="/terms">Termos e Condições</Link>
+      </p>
+      <p>
+        <a href="mailto:suporte@sunnysales.com">Contactar Suporte</a>
+      </p>
+    </div>
+  );
+}
+
+export default AboutPage;

--- a/web/src/pages/AccountSettingsPage.js
+++ b/web/src/pages/AccountSettingsPage.js
@@ -1,0 +1,28 @@
+// Página para alterar definições como notificações
+import { useEffect, useState } from 'react';
+import { isNotificationsEnabled, setNotificationsEnabled } from '../services/settings';
+
+function AccountSettingsPage() {
+  const [enabled, setEnabled] = useState(true);
+
+  useEffect(() => {
+    setEnabled(isNotificationsEnabled());
+  }, []);
+
+  const toggle = () => {
+    const val = !enabled;
+    setEnabled(val);
+    setNotificationsEnabled(val);
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Notificações</h1>
+      <label>
+        <input type="checkbox" checked={enabled} onChange={toggle} /> Ativar
+      </label>
+    </div>
+  );
+}
+
+export default AccountSettingsPage;

--- a/web/src/pages/ClientDashboardPage.js
+++ b/web/src/pages/ClientDashboardPage.js
@@ -1,0 +1,41 @@
+// Página principal para clientes autenticados
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { fetchFavorites } from '../services/api';
+import { getFavorites } from '../services/favorites';
+
+function ClientDashboardPage() {
+  const navigate = useNavigate();
+  const [favorites, setFavorites] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const ids = getFavorites();
+      if (ids.length === 0) return;
+      const vendors = await fetchFavorites(ids);
+      setFavorites(vendors);
+    };
+    load();
+  }, []);
+
+  const logout = () => {
+    localStorage.removeItem('client');
+    localStorage.removeItem('clientToken');
+    navigate('/client/login');
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Perfil do Cliente</h1>
+      <h2>Favoritos</h2>
+      <ul>
+        {favorites.map((v) => (
+          <li key={v.id}>{v.name}</li>
+        ))}
+      </ul>
+      <button onClick={logout}>Sair</button>
+    </div>
+  );
+}
+
+export default ClientDashboardPage;

--- a/web/src/pages/ClientLoginPage.js
+++ b/web/src/pages/ClientLoginPage.js
@@ -1,0 +1,48 @@
+// Página de login para clientes
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { clientLogin, fetchClientProfile } from '../services/api';
+
+function ClientLoginPage() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const data = await clientLogin(email, password);
+      localStorage.setItem('clientToken', data.access_token);
+      const id = JSON.parse(atob(data.access_token.split('.')[1])).sub;
+      const profile = await fetchClientProfile(id);
+      localStorage.setItem('client', JSON.stringify(profile));
+      navigate('/client');
+    } catch {
+      setError('Credenciais inválidas');
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: '400px', margin: '2rem auto' }}>
+      <h1>Login Cliente</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+        />
+        <button type="submit">Entrar</button>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+      </form>
+    </div>
+  );
+}
+
+export default ClientLoginPage;

--- a/web/src/pages/ClientRegisterPage.js
+++ b/web/src/pages/ClientRegisterPage.js
@@ -1,0 +1,51 @@
+// Página de registo de novos clientes
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { registerClient } from '../services/api';
+
+function ClientRegisterPage() {
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await registerClient({ name, email, password });
+      alert('Registo efetuado. Verifique o seu email.');
+      navigate('/client/login');
+    } catch {
+      setError('Erro no registo');
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: '400px', margin: '2rem auto' }}>
+      <h1>Registar Cliente</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Nome"
+        />
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+        />
+        <button type="submit">Registar</button>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+      </form>
+    </div>
+  );
+}
+
+export default ClientRegisterPage;

--- a/web/src/pages/ForgotPasswordPage.js
+++ b/web/src/pages/ForgotPasswordPage.js
@@ -1,0 +1,38 @@
+// Página para solicitar recuperação de palavra-passe
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { requestPasswordReset } from '../services/api';
+
+function ForgotPasswordPage() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await requestPasswordReset(email);
+      alert('Verifique o seu e-mail para definir nova palavra-passe');
+      navigate('/login');
+    } catch {
+      setError('Erro ao solicitar recuperação');
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: '400px', margin: '2rem auto' }}>
+      <h1>Recuperar Palavra-passe</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+        />
+        <button type="submit">Enviar</button>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+      </form>
+    </div>
+  );
+}
+
+export default ForgotPasswordPage;

--- a/web/src/pages/ManageAccountPage.js
+++ b/web/src/pages/ManageAccountPage.js
@@ -1,0 +1,20 @@
+// Página com ações para alteração e remoção de conta
+function ManageAccountPage() {
+  const changePassword = () => {
+    alert('Funcionalidade indisponível');
+  };
+
+  const deleteAccount = () => {
+    alert('Funcionalidade indisponível');
+  };
+
+  return (
+    <div style={{ maxWidth: '400px', margin: '2rem auto' }}>
+      <h1>Definições de Conta</h1>
+      <button onClick={changePassword}>Alterar Palavra-passe</button>
+      <button onClick={deleteAccount}>Apagar Conta</button>
+    </div>
+  );
+}
+
+export default ManageAccountPage;

--- a/web/src/pages/PaidWeeksPage.js
+++ b/web/src/pages/PaidWeeksPage.js
@@ -1,0 +1,26 @@
+// Página que lista semanas pagas pelo vendedor
+import { useEffect, useState } from 'react';
+import { fetchPaidWeeks } from '../services/api';
+
+function PaidWeeksPage() {
+  const [weeks, setWeeks] = useState([]);
+
+  useEffect(() => {
+    fetchPaidWeeks().then(setWeeks).catch(() => setWeeks([]));
+  }, []);
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Semanas Pagas</h1>
+      <ul>
+        {weeks.map((w) => (
+          <li key={w.id}>
+            {w.start_date} - {w.end_date}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default PaidWeeksPage;

--- a/web/src/pages/RegisterPage.js
+++ b/web/src/pages/RegisterPage.js
@@ -1,0 +1,57 @@
+// Página de registo de novos vendedores
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { registerVendor } from '../services/api';
+
+function RegisterPage() {
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [product, setProduct] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await registerVendor({ name, email, password, product });
+      alert('Registo efetuado. Verifique o seu email.');
+      navigate('/login');
+    } catch {
+      setError('Erro no registo');
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: '400px', margin: '2rem auto' }}>
+      <h1>Registar Vendedor</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Nome"
+        />
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+        />
+        <input
+          value={product}
+          onChange={(e) => setProduct(e.target.value)}
+          placeholder="Produto"
+        />
+        <button type="submit">Registar</button>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+      </form>
+    </div>
+  );
+}
+
+export default RegisterPage;

--- a/web/src/pages/RouteDetailPage.js
+++ b/web/src/pages/RouteDetailPage.js
@@ -1,0 +1,36 @@
+// Página com detalhes de um trajeto específico
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { MapContainer, TileLayer, Polyline } from 'react-leaflet';
+import { fetchRoute } from '../services/api';
+import 'leaflet/dist/leaflet.css';
+
+function RouteDetailPage() {
+  const { id } = useParams();
+  const [route, setRoute] = useState(null);
+
+  useEffect(() => {
+    fetchRoute(id).then(setRoute).catch(() => setRoute(null));
+  }, [id]);
+
+  if (!route) return <p>Carregando...</p>;
+
+  const polyline = route.points.map((p) => [p.lat, p.lng]);
+  const position = polyline.length ? polyline[0] : [0, 0];
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Detalhes do Trajeto</h1>
+      <MapContainer center={position} zoom={13} style={{ height: '300px' }}>
+        <TileLayer
+          attribution='&copy; OpenStreetMap'
+          url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+        />
+        <Polyline positions={polyline} />
+      </MapContainer>
+      <p>Distância: {(route.distance_m / 1000).toFixed(2)} km</p>
+    </div>
+  );
+}
+
+export default RouteDetailPage;

--- a/web/src/pages/RoutesPage.js
+++ b/web/src/pages/RoutesPage.js
@@ -1,0 +1,27 @@
+// Página que lista trajetos registados pelo vendedor
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchVendorRoutes } from '../services/api';
+
+function RoutesPage() {
+  const [routes, setRoutes] = useState([]);
+
+  useEffect(() => {
+    fetchVendorRoutes().then(setRoutes).catch(() => setRoutes([]));
+  }, []);
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Trajetos</h1>
+      <ul>
+        {routes.map((r) => (
+          <li key={r.id}>
+            <Link to={`/routes/${r.id}`}>{r.start_time}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default RoutesPage;

--- a/web/src/pages/StatsPage.js
+++ b/web/src/pages/StatsPage.js
@@ -1,0 +1,38 @@
+// Página que exibe um gráfico simples das distâncias percorridas
+import { useEffect, useState } from 'react';
+import { Bar } from 'react-chartjs-2';
+import { fetchVendorRoutes } from '../services/api';
+
+function StatsPage() {
+  const [chartData, setChartData] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const routes = await fetchVendorRoutes();
+        const daily = {};
+        routes.forEach((r) => {
+          const d = r.start_time.split('T')[0];
+          daily[d] = (daily[d] || 0) + r.distance_m;
+        });
+        const labels = Object.keys(daily);
+        const data = labels.map((d) => Number((daily[d] / 1000).toFixed(2)));
+        setChartData({ labels, datasets: [{ label: 'Km', data }] });
+      } catch {
+        setChartData(null);
+      }
+    };
+    load();
+  }, []);
+
+  if (!chartData) return <p>Nenhum dado</p>;
+
+  return (
+    <div style={{ maxWidth: '600px', margin: '2rem auto' }}>
+      <h1>Estatísticas</h1>
+      <Bar data={chartData} />
+    </div>
+  );
+}
+
+export default StatsPage;

--- a/web/src/pages/TermsPage.js
+++ b/web/src/pages/TermsPage.js
@@ -1,0 +1,63 @@
+// Página web que mostra os Termos e Condições completos
+import React from 'react';
+
+function TermsPage() {
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Termos e Condições</h1>
+      <h2>1. Aceitação dos Termos</h2>
+      <p>
+        Ao criar uma conta e utilizar a aplicação Sunny Sales, o utilizador
+        (vendedor) concorda com estes Termos e Condições. Caso não concorde, não
+        deve utilizar a aplicação.
+      </p>
+      <h2>2. Registo e Conta</h2>
+      <p>
+        O vendedor é responsável por fornecer informações verdadeiras e
+        atualizadas no momento do registo. A falsificação de dados poderá
+        resultar no cancelamento da conta.
+      </p>
+      <h2>3. Privacidade e Partilha de Localização</h2>
+      <p>
+        A aplicação recolhe e partilha a localização do vendedor apenas durante o
+        período em que este estiver ativo. Esta localização é visível
+        publicamente aos clientes para fins de identificação de vendedores
+        disponíveis.
+      </p>
+      <h2>4. Pagamentos e Subscrição</h2>
+      <p>
+        O pagamento da subscrição semanal é obrigatório para manter a conta
+        ativa e visível no mapa. O não pagamento pode suspender temporariamente
+        ou cancelar a conta até que a situação seja regularizada.
+      </p>
+      <h2>5. Obrigações do Vendedor</h2>
+      <p>
+        O vendedor compromete-se a cumprir a legislação aplicável, garantir a
+        qualidade dos produtos e não utilizar a aplicação para fins ilegais.
+      </p>
+      <h2>6. Suspensão e Cancelamento</h2>
+      <p>
+        A administração da Sunny Sales pode suspender ou cancelar contas que
+        violem estes termos ou utilizem a aplicação de forma abusiva.
+      </p>
+      <h2>7. Limitação de Responsabilidade</h2>
+      <p>
+        A Sunny Sales não se responsabiliza por perdas ou danos resultantes de
+        transações comerciais entre vendedores e clientes. O uso da aplicação é
+        da responsabilidade do utilizador.
+      </p>
+      <h2>8. Alterações aos Termos</h2>
+      <p>
+        Estes termos podem ser atualizados periodicamente. Notificaremos os
+        utilizadores em caso de alterações significativas.
+      </p>
+      <h2>9. Contacto</h2>
+      <p>
+        Para dúvidas contacte a equipa de suporte através do email:
+        suporte@sunnysales.com
+      </p>
+    </div>
+  );
+}
+
+export default TermsPage;

--- a/web/src/pages/VendorDetailPage.js
+++ b/web/src/pages/VendorDetailPage.js
@@ -1,0 +1,27 @@
+// Página que mostra detalhes de um vendedor
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { fetchVendor } from '../services/api';
+
+function VendorDetailPage() {
+  const { id } = useParams();
+  const [vendor, setVendor] = useState(null);
+
+  useEffect(() => {
+    fetchVendor(id).then(setVendor).catch(() => setVendor(null));
+  }, [id]);
+
+  if (!vendor) return <p>Carregando...</p>;
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>{vendor.name}</h1>
+      {vendor.profile_photo && (
+        <img src={vendor.profile_photo} alt={vendor.name} width={120} />
+      )}
+      <p>Produto: {vendor.product}</p>
+    </div>
+  );
+}
+
+export default VendorDetailPage;

--- a/web/src/services/api.js
+++ b/web/src/services/api.js
@@ -1,13 +1,16 @@
 import axios from 'axios';
 import { BASE_URL } from '../config';
 
+// Instância pré-configurada do axios para apontar para o backend
 const api = axios.create({
   baseURL: BASE_URL,
 });
 
+// Login de vendedores
 export const login = (email, password) =>
   api.post('/token', { email, password }).then((r) => r.data);
 
+// Obtém o perfil do vendedor autenticado
 export const fetchVendorProfile = (token) =>
   api
     .get('/vendors/me', {
@@ -15,6 +18,7 @@ export const fetchVendorProfile = (token) =>
     })
     .then((r) => r.data);
 
+// Atualiza localização do vendedor
 export const updateVendorLocation = (token, coords) =>
   api
     .put('/vendors/me/location', coords, {
@@ -22,7 +26,48 @@ export const updateVendorLocation = (token, coords) =>
     })
     .then((r) => r.data);
 
+// Lista vendedores ativos visíveis no mapa
 export const fetchActiveVendors = () =>
   api.get('/vendors').then((r) => r.data);
+
+// Login de clientes
+export const clientLogin = (email, password) =>
+  api.post('/client-token', { email, password }).then((r) => r.data);
+
+// Registo de novo vendedor
+export const registerVendor = (data) =>
+  api.post('/vendors/', data).then((r) => r.data);
+
+// Registo de novo cliente
+export const registerClient = (data) =>
+  api.post('/clients/', data).then((r) => r.data);
+
+// Solicita recuperação de palavra-passe
+export const requestPasswordReset = (email) =>
+  api.post('/password-reset-request', { email });
+
+// Lista trajetos do vendedor autenticado
+export const fetchVendorRoutes = () =>
+  api.get('/vendors/me/routes').then((r) => r.data);
+
+// Obtém detalhes de trajeto específico
+export const fetchRoute = (id) =>
+  api.get(`/routes/${id}`).then((r) => r.data);
+
+// Obtém detalhes de um vendedor
+export const fetchVendor = (id) =>
+  api.get(`/vendors/${id}`).then((r) => r.data);
+
+// Lista semanas já pagas
+export const fetchPaidWeeks = () =>
+  api.get('/vendors/me/paid-weeks').then((r) => r.data);
+
+// Lista vendedores favoritos dados os IDs
+export const fetchFavorites = (ids) =>
+  api.get('/vendors').then((r) => r.data.filter((v) => ids.includes(v.id)));
+
+// Obtém perfil de cliente
+export const fetchClientProfile = (id) =>
+  api.get(`/clients/${id}`).then((r) => r.data);
 
 export default api;

--- a/web/src/services/favorites.js
+++ b/web/src/services/favorites.js
@@ -1,0 +1,25 @@
+// Serviço utilitário para gerir vendedores favoritos no localStorage
+const KEY = 'favorites';
+
+export function getFavorites() {
+  const data = localStorage.getItem(KEY);
+  return data ? JSON.parse(data) : [];
+}
+
+export function addFavorite(id) {
+  const favs = getFavorites();
+  if (!favs.includes(id)) {
+    favs.push(id);
+    localStorage.setItem(KEY, JSON.stringify(favs));
+  }
+}
+
+export function removeFavorite(id) {
+  let favs = getFavorites();
+  favs = favs.filter((v) => v !== id);
+  localStorage.setItem(KEY, JSON.stringify(favs));
+}
+
+export function clearFavorites() {
+  localStorage.removeItem(KEY);
+}

--- a/web/src/services/settings.js
+++ b/web/src/services/settings.js
@@ -1,0 +1,11 @@
+// Guardar e ler definições de notificações no localStorage
+const ENABLED_KEY = 'notifications_enabled';
+
+export function isNotificationsEnabled() {
+  const val = localStorage.getItem(ENABLED_KEY);
+  return val !== 'false';
+}
+
+export function setNotificationsEnabled(enabled) {
+  localStorage.setItem(ENABLED_KEY, enabled ? 'true' : 'false');
+}


### PR DESCRIPTION
## Summary
- create new React pages to mirror mobile screens
- add API helper functions with comments
- expose new routes in `App.js`
- add services for favorites and settings
- include chart library for stats page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ec8cc7048832e93cfeee861453f3f