### PR TITLE
Fix web assets for browser

### DIFF
--- a/web/src/pages/PublicMapPage.js
+++ b/web/src/pages/PublicMapPage.js
@@ -2,6 +2,18 @@ import { useEffect, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import { fetchActiveVendors } from '../services/api';
 import 'leaflet/dist/leaflet.css';
+import L from 'leaflet';
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+
+// fix default icon paths for webpack
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: markerIcon2x,
+  iconUrl: markerIcon,
+  shadowUrl: markerShadow,
+});
 import styles from './PublicMapPage.module.css';
 
 // PublicMapPage

--- a/web/src/pages/StatsPage.js
+++ b/web/src/pages/StatsPage.js
@@ -1,6 +1,7 @@
 // Página que exibe um gráfico simples das distâncias percorridas
 import { useEffect, useState } from 'react';
 import { Bar } from 'react-chartjs-2';
+import 'chart.js/auto';
 import { fetchVendorRoutes } from '../services/api';
 
 // StatsPage


### PR DESCRIPTION
## Summary
- fix chart.js imports so stats page renders graphs
- correct Leaflet icon paths for marker display

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eed670594832ebb84a8c8e3337367