### PR TITLE
Update web folder docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Aplicação composta por backend em **FastAPI** e app móvel em **React Native**
 ## Estrutura
 
 ```
-backend/    Código do servidor FastAPI
-mobile/     Aplicação React Native (Expo)
-web/        Site React para navegadores
-scripts/    Utilidades auxiliares
+backend/        Código do servidor FastAPI
+mobile/         Aplicação React Native (Expo)
+sunny_sales_web/  Site React para navegadores
+scripts/        Utilidades auxiliares
 ```
 
 ## Configuração Rápida
@@ -32,11 +32,12 @@ scripts/    Utilidades auxiliares
    npm install
    npx expo start
    ```
-6. Para o site Web entre em `web`, instale dependências e execute:
+6. Para o site Web entre em `sunny_sales_web`, instale dependências e execute:
    ```bash
    npm install
-   npm start
+   npm run dev
    ```
+   Pode definir a variável `VITE_BASE_URL` para apontar para o endereço do backend.
 
 ## Novidades
 
@@ -44,7 +45,7 @@ scripts/    Utilidades auxiliares
 - **Favoritos**: clientes podem marcar vendedores favoritos para receber notificações de proximidade.
 - **Respostas a reviews**: vendedores podem responder ou ocultar avaliações via API.
 - **Tradução e acessibilidade**: interface com suporte a português e inglês e elementos com labels acessíveis.
-   A variável `BASE_URL` em `mobile/config.js` deve apontar para o endereço do backend.
+  A variável `BASE_URL` em `mobile/config.js` e `VITE_BASE_URL` para o site devem apontar para o endereço do backend.
 
 ## Testes
 

--- a/sunny_sales_web/README.md
+++ b/sunny_sales_web/README.md
@@ -1,12 +1,12 @@
-# React + Vite
+# Sunny Sales - Web
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Aplicação web em React utilizando Vite.
 
-Currently, two official plugins are available:
+## Desenvolvimento
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+```bash
+npm install
+npm run dev
+```
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+Defina `VITE_BASE_URL` para apontar para o backend (por omissão `http://localhost:8000`).

--- a/sunny_sales_web/src/config.js
+++ b/sunny_sales_web/src/config.js
@@ -1,2 +1,4 @@
-// (em português) URL base do backend local
-export const BASE_URL = 'http://localhost:8000';
+// (em português) URL base do backend.
+// Pode ser definida pela variável de ambiente `VITE_BASE_URL` quando
+// iniciar o Vite. Caso não seja fornecida, assume localhost.
+export const BASE_URL = import.meta.env.VITE_BASE_URL || 'http://localhost:8000';


### PR DESCRIPTION
## Summary
- tweak sunny_sales_web config to read `VITE_BASE_URL`
- update root README to mention `sunny_sales_web` folder
- provide custom instructions for the web project

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685f0e6a5310832e9cd39da0e26a32f8