### PR TITLE
Update web routing and pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Aplicação composta por backend em **FastAPI** e app móvel em **React Native**
 ## Estrutura
 
 ```
-backend/    Código do servidor FastAPI
-mobile/     Aplicação React Native (Expo)
-web/        Site React para navegadores
-scripts/    Utilidades auxiliares
+backend/        Código do servidor FastAPI
+mobile/         Aplicação React Native (Expo)
+sunny_sales_web/  Site React para navegadores
+scripts/        Utilidades auxiliares
 ```
 
 ## Configuração Rápida
@@ -32,11 +32,12 @@ scripts/    Utilidades auxiliares
    npm install
    npx expo start
    ```
-6. Para o site Web entre em `web`, instale dependências e execute:
+6. Para o site Web entre em `sunny_sales_web`, instale dependências e execute:
    ```bash
    npm install
-   npm start
+   npm run dev
    ```
+   Pode definir a variável `VITE_BASE_URL` para apontar para o endereço do backend.
 
 ## Novidades
 
@@ -44,7 +45,7 @@ scripts/    Utilidades auxiliares
 - **Favoritos**: clientes podem marcar vendedores favoritos para receber notificações de proximidade.
 - **Respostas a reviews**: vendedores podem responder ou ocultar avaliações via API.
 - **Tradução e acessibilidade**: interface com suporte a português e inglês e elementos com labels acessíveis.
-   A variável `BASE_URL` em `mobile/config.js` deve apontar para o endereço do backend.
+  A variável `BASE_URL` em `mobile/config.js` e `VITE_BASE_URL` para o site devem apontar para o endereço do backend.
 
 ## Testes
 

--- a/sunny_sales_web/README.md
+++ b/sunny_sales_web/README.md
@@ -1,12 +1,12 @@
-# React + Vite
+# Sunny Sales - Web
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Aplicação web em React utilizando Vite.
 
-Currently, two official plugins are available:
+## Desenvolvimento
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+```bash
+npm install
+npm run dev
+```
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+Defina `VITE_BASE_URL` para apontar para o backend (por omissão `http://localhost:8000`).

--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -16,6 +16,8 @@ import RoutesScreen from './pages/RoutesScreen';
 import StatsScreen from './pages/StatsScreen';
 import TermsScreen from './pages/TermsScreen';
 import VendorDetailScreen from './pages/VendorDetailScreen';
+import Invoices from './pages/Invoices';
+import Dashboard from './pages/Dashboard';
 
 
 
@@ -40,6 +42,7 @@ return (
     <Route path="/vendor-login" element={<VendorLogin />} />
     <Route path="/account" element={<ManageAccount />} />
     <Route path="/paid-weeks" element={<PaidWeeksScreen />} />
+    <Route path="/invoices" element={<Invoices />} />
     <Route path="/map" element={<MapScreen />} />
     <Route path="/vendor-register" element={<VendorRegister />} />
     <Route path="/route-detail" element={<RouteDetail />} />
@@ -47,6 +50,7 @@ return (
     <Route path="/stats" element={<StatsScreen />} />
     <Route path="/terms" element={<TermsScreen />} />
     <Route path="/vendors/:id" element={<VendorDetailScreen />} />
+    <Route path="/dashboard" element={<Dashboard />} />
 
 
   </Routes>

--- a/sunny_sales_web/src/config.js
+++ b/sunny_sales_web/src/config.js
@@ -1,2 +1,4 @@
-// (em português) URL base do backend local
-export const BASE_URL = 'http://localhost:8000';
+// (em português) URL base do backend.
+// Pode ser definida pela variável de ambiente `VITE_BASE_URL` quando
+// iniciar o Vite. Caso não seja fornecida, assume localhost.
+export const BASE_URL = import.meta.env.VITE_BASE_URL || 'http://localhost:8000';

--- a/sunny_sales_web/src/pages/ClientLogin.jsx
+++ b/sunny_sales_web/src/pages/ClientLogin.jsx
@@ -3,8 +3,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
-
-const BASE_URL = 'https://ss-tester.onrender.com';
+import { BASE_URL } from '../config';
 
 export default function ClientLogin() {
   const [email, setEmail] = useState('');

--- a/sunny_sales_web/src/pages/ClientRegister.jsx
+++ b/sunny_sales_web/src/pages/ClientRegister.jsx
@@ -3,8 +3,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
-
-const BASE_URL = 'https://ss-tester.onrender.com';
+import { BASE_URL } from '../config';
 
 export default function ClientRegister() {
   const [name, setName] = useState('');

--- a/sunny_sales_web/src/pages/Dashboard.jsx
+++ b/sunny_sales_web/src/pages/Dashboard.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import DashboardCliente from './DashboardCliente';
+import VendorDashboard from './VendorDashboard';
+
+export default function Dashboard() {
+  const hasClient = !!localStorage.getItem('client');
+  const hasVendor = !!localStorage.getItem('user');
+
+  if (hasClient) return <DashboardCliente />;
+  if (hasVendor) return <VendorDashboard />;
+  return <p style={{ padding: '2rem', textAlign: 'center' }}>Utilizador não autenticado.</p>;
+}

--- a/sunny_sales_web/src/pages/DashboardCliente.jsx
+++ b/sunny_sales_web/src/pages/DashboardCliente.jsx
@@ -3,8 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';
-
-const BASE_URL = 'https://ss-tester.onrender.com';
+import { BASE_URL } from '../config';
 
 export default function DashboardCliente() {
   const [client, setClient] = useState(null);

--- a/sunny_sales_web/src/pages/Invoices.jsx
+++ b/sunny_sales_web/src/pages/Invoices.jsx
@@ -1,0 +1,83 @@
+// (em português) Histórico de faturas do vendedor
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { BASE_URL } from '../config';
+import { useNavigate } from 'react-router-dom';
+
+export default function Invoices() {
+  const [weeks, setWeeks] = useState([]);
+  const navigate = useNavigate();
+
+  const loadWeeks = async () => {
+    const stored = localStorage.getItem('user');
+    const token = localStorage.getItem('token');
+    if (!stored) return;
+    const vendor = JSON.parse(stored);
+    try {
+      const res = await axios.get(`${BASE_URL}/vendors/${vendor.id}/paid-weeks`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      setWeeks(res.data);
+    } catch (e) {
+      console.error('Erro ao carregar semanas:', e);
+    }
+  };
+
+  useEffect(() => {
+    loadWeeks();
+  }, []);
+
+  return (
+    <div style={styles.container}>
+      <button onClick={() => navigate(-1)} style={styles.back}>⬅ Voltar</button>
+      <h2>Faturas Pagas</h2>
+      <ul style={styles.list}>
+        {weeks.map((item) => {
+          const start = new Date(item.start_date).toLocaleDateString();
+          const end = new Date(item.end_date).toLocaleDateString();
+          return (
+            <li key={item.id} style={styles.item}>
+              <span>{start} - {end}</span>
+              {item.receipt_url && (
+                <a href={item.receipt_url} target="_blank" rel="noopener noreferrer" style={styles.link}>
+                  Recibo
+                </a>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    padding: '2rem',
+    fontFamily: 'Arial',
+  },
+  list: {
+    listStyle: 'none',
+    padding: 0,
+  },
+  item: {
+    padding: '1rem 0',
+    borderBottom: '1px solid #ccc',
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+  link: {
+    marginLeft: '1rem',
+    textDecoration: 'none',
+    color: '#0077ff',
+    fontWeight: 'bold',
+  },
+  back: {
+    marginBottom: '1rem',
+    background: 'none',
+    border: 'none',
+    color: '#0077ff',
+    fontSize: '1rem',
+    cursor: 'pointer',
+  },
+};

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { BASE_URL } from '../config';
+
+export default function VendorDashboard() {
+  const [vendor, setVendor] = useState(null);
+  const navigate = useNavigate();
+
+  // carrega dados do vendedor guardados no localStorage
+  useEffect(() => {
+    const stored = localStorage.getItem('user');
+    if (stored) {
+      setVendor(JSON.parse(stored));
+    }
+  }, []);
+
+  const logout = () => {
+    localStorage.removeItem('user');
+    localStorage.removeItem('token');
+    navigate('/vendor-login');
+  };
+
+  return (
+    <div style={styles.container}>
+      <h2 style={styles.title}>Painel do Vendedor</h2>
+      {vendor && (
+        <>
+          {vendor.profile_photo && (
+            <img
+              src={`${BASE_URL.replace(/\/$/, '')}/${vendor.profile_photo}`}
+              alt="Foto"
+              style={styles.photo}
+            />
+          )}
+          <p><strong>Nome:</strong> {vendor.name}</p>
+          <p><strong>Produto:</strong> {vendor.product}</p>
+          {vendor.subscription_active && (
+            <p style={styles.subActive}>Subscrição ativa</p>
+          )}
+        </>
+      )}
+
+      <div style={styles.links}>
+        <Link style={styles.link} to="/routes">Trajetos</Link>
+        <Link style={styles.link} to="/paid-weeks">Semanas Pagas</Link>
+        <Link style={styles.link} to="/stats">Estatísticas</Link>
+        <Link style={styles.link} to="/account">Conta</Link>
+      </div>
+      <button style={styles.logout} onClick={logout}>Sair</button>
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    padding: '2rem',
+    maxWidth: '600px',
+    margin: '0 auto',
+    textAlign: 'center',
+  },
+  title: {
+    marginBottom: '1rem',
+  },
+  photo: {
+    width: 100,
+    height: 100,
+    borderRadius: '50%',
+    objectFit: 'cover',
+    marginBottom: '1rem',
+  },
+  links: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+    margin: '1rem 0',
+  },
+  link: {
+    textDecoration: 'none',
+    color: '#0077cc',
+  },
+  subActive: {
+    color: 'green',
+    fontWeight: 'bold',
+  },
+  logout: {
+    marginTop: '1rem',
+    padding: '0.5rem 1rem',
+    border: 'none',
+    borderRadius: '8px',
+    backgroundColor: '#f9c200',
+    cursor: 'pointer',
+  },
+};


### PR DESCRIPTION
## Summary
- port missing web pages from mobile
- add `Dashboard` router with vendor and client views
- implement `Invoices` page
- route `/dashboard` and `/invoices` in App
- fix BASE_URL usage across pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685f0e6a5310832e9cd39da0e26a32f8