### PR TITLE
Align map page with navbar

### DIFF
--- a/sunny_sales_web/src/pages/MapScreen.jsx
+++ b/sunny_sales_web/src/pages/MapScreen.jsx
@@ -66,7 +66,7 @@ export default function MapScreenWeb() {
   }, []);
 
   return (
-    <div style={{ padding: '1rem' }}>
+    <div style={{ padding: '1rem 2rem' }}>
       <h2>🌞 Localização dos Vendedores</h2>
 
       <div style={{ marginBottom: '1rem' }}>


### PR DESCRIPTION
## Summary
- adjust MapScreen padding on the web

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_688c8a898898832e97a3712585119976